### PR TITLE
Add old name support for Name-service

### DIFF
--- a/internal/provider/name_services/name_services_dns_data_source.go
+++ b/internal/provider/name_services/name_services_dns_data_source.go
@@ -26,6 +26,15 @@ func NewNameServicesDNSDataSource() datasource.DataSource {
 	}
 }
 
+// NewNameServicesDNSDataSourceAlias is a helper function to simplify the provider implementation.
+func NewNameServicesDNSDataSourceAlias() datasource.DataSource {
+	return &NameServicesDNSDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "name_services_dns_data_source",
+		},
+	}
+}
+
 // NameServicesDNSDataSource defines the data source implementation.
 type NameServicesDNSDataSource struct {
 	config connection.ResourceOrDataSourceConfig

--- a/internal/provider/name_services/name_services_dns_resource.go
+++ b/internal/provider/name_services/name_services_dns_resource.go
@@ -32,6 +32,15 @@ func NewNameServicesDNSResource() resource.Resource {
 	}
 }
 
+// NewNameServicesDNSResourceAlias is a helper function to simplify the provider implementation.
+func NewNameServicesDNSResourceAlias() resource.Resource {
+	return &NameServicesDNSResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "name_services_dns_resource",
+		},
+	}
+}
+
 // NameServicesDNSResource defines the resource implementation.
 type NameServicesDNSResource struct {
 	config connection.ResourceOrDataSourceConfig

--- a/internal/provider/name_services/name_services_dns_resource_alias_test.go
+++ b/internal/provider/name_services/name_services_dns_resource_alias_test.go
@@ -1,0 +1,75 @@
+package name_services_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+)
+
+func TestAccNameServicesDNSResourceAlias(t *testing.T) {
+	svmName := "ansibleSVM"
+	credName := "cluster4"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// non-existant SVM return code 2621462. Must happen before create/read
+			{
+				Config:      testAccNameServicesDNSResourceConfigAlias("non-existant"),
+				ExpectError: regexp.MustCompile("2621462"),
+			},
+			{
+				Config: testAccNameServicesDNSResourceConfigAlias("svm5"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_dns_resource.dns", "svm_name", "svm5"),
+				),
+			},
+			// Test importing a resource
+			{
+				ResourceName:  "netapp-ontap_name_services_dns_resource.dns",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s", svmName, credName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_dns_resource.dns", "svm_name", "ansibleSVM"),
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_dns_resource.dns", "name_servers.0", "netappad.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNameServicesDNSResourceConfigAlias(svmName string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_name_services_dns_resource" "dns" {
+  # required to know which system to interface with
+  cx_profile_name = "cluster4"
+  svm_name = "%s"
+  name_servers = ["1.1.1.1", "2.2.2.2"]
+  dns_domains = ["foo.bar.com", "boo.bar.com"]
+  skip_config_validation = true
+}
+`, host, admin, password, svmName)
+}

--- a/internal/provider/name_services/name_services_dnss_data_source.go
+++ b/internal/provider/name_services/name_services_dnss_data_source.go
@@ -26,6 +26,15 @@ func NewNameServicesDNSsDataSource() datasource.DataSource {
 	}
 }
 
+// NewNameServicesDNSsDataSourceAlias is a helper function to simplify the provider implementation.
+func NewNameServicesDNSsDataSourceAlias() datasource.DataSource {
+	return &NameServicesDNSsDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "name_services_dnss_data_source",
+		},
+	}
+}
+
 // NameServicesDNSsDataSource defines the data source implementation.
 type NameServicesDNSsDataSource struct {
 	config connection.ResourceOrDataSourceConfig

--- a/internal/provider/name_services/name_services_ldap_data_source.go
+++ b/internal/provider/name_services/name_services_ldap_data_source.go
@@ -3,6 +3,7 @@ package name_services
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,6 +22,15 @@ func NewNameServicesLDAPDataSource() datasource.DataSource {
 	return &NameServicesLDAPDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "name_services_ldap",
+		},
+	}
+}
+
+// NewNameServicesLDAPDataSourceAlias is a helper function to simplify the provider implementation.
+func NewNameServicesLDAPDataSourceAlias() datasource.DataSource {
+	return &NameServicesLDAPDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "name_services_ldap_data_source",
 		},
 	}
 }

--- a/internal/provider/name_services/name_services_ldap_resource.go
+++ b/internal/provider/name_services/name_services_ldap_resource.go
@@ -35,6 +35,15 @@ func NewNameServicesLDAPResource() resource.Resource {
 	}
 }
 
+// NewNameServicesLDAPResourceAlias is a helper function to simplify the provider implementation.
+func NewNameServicesLDAPResourceAlias() resource.Resource {
+	return &NameServicesLDAPResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "name_services_ldap_resource",
+		},
+	}
+}
+
 // NameServicesLDAPResource defines the resource implementation.
 type NameServicesLDAPResource struct {
 	config connection.ResourceOrDataSourceConfig

--- a/internal/provider/name_services/name_services_ldap_resource_alias_test.go
+++ b/internal/provider/name_services/name_services_ldap_resource_alias_test.go
@@ -1,0 +1,86 @@
+package name_services_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNameServicesLDAPResourceAlias(t *testing.T) {
+	svmName := "accsvm"
+	credName := "cluster4"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// non-existant SVM return code 2621462. Must happen before create/read
+			{
+				Config:      testAccNameServicesLDAPResourceConfigAlias("non-existant", "subtree"),
+				ExpectError: regexp.MustCompile("2621462"),
+			},
+			// Test create
+			{
+				Config: testAccNameServicesLDAPResourceConfigAlias("svm1", "subtree"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_ldap_resource.name_services_ldap", "svm_name", "svm1"),
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_ldap_resource.name_services_ldap", "servers.0", "1.1.1.1"),
+				),
+			},
+			// Test update
+			{
+				Config: testAccNameServicesLDAPResourceConfigAlias("svm1", "base"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_ldap_resource.name_services_ldap", "svm_name", "svm1"),
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_ldap_resource.name_services_ldap", "base_scope", "base"),
+				),
+			},
+			// Test importing a resource
+			{
+				ResourceName:  "netapp-ontap_name_services_ldap_resource.name_services_ldap",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s", svmName, credName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_ldap_resource.name_services_ldap", "svm_name", svmName),
+					resource.TestCheckResourceAttr("netapp-ontap_name_services_ldap_resource.name_services_ldap", "servers.0", "acc1.test.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNameServicesLDAPResourceConfigAlias(svmName string, baseScope string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_name_services_ldap_resource" "name_services_ldap" {
+  # required to know which system to interface with
+  cx_profile_name = "cluster4"
+  svm_name = "%s"
+  servers = ["1.1.1.1", "2.2.2.2"]
+  base_scope = "%s"
+  skip_config_validation = true
+}
+`, host, admin, password, svmName, baseScope)
+}

--- a/internal/provider/name_services/name_services_ldaps_data_source.go
+++ b/internal/provider/name_services/name_services_ldaps_data_source.go
@@ -3,6 +3,7 @@ package name_services
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,6 +22,15 @@ func NewNameServicesLDAPsDataSource() datasource.DataSource {
 	return &NameServicesLDAPsDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "name_services_ldaps",
+		},
+	}
+}
+
+// NewNameServicesLDAPsDataSourceAlias is a helper function to simplify the provider implementation.
+func NewNameServicesLDAPsDataSourceAlias() datasource.DataSource {
+	return &NameServicesLDAPsDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "name_services_ldaps_data_source",
 		},
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -257,6 +257,8 @@ func (p *ONTAPProvider) Resources(ctx context.Context) []func() resource.Resourc
 		cluster.NewClusterPeerResourceAlias,
 		cluster.NewClusterResourceAlias,
 		cluster.NewClusterScheduleResourceAlias,
+		name_services.NewNameServicesDNSResourceAlias,
+		name_services.NewNameServicesLDAPResourceAlias,
 	}
 }
 
@@ -345,6 +347,10 @@ func (p *ONTAPProvider) DataSources(ctx context.Context) []func() datasource.Dat
 		cluster.NewClusterPeersDataSourceAlias,
 		cluster.NewClusterScheduleDataSourceAlias,
 		cluster.NewClusterSchedulesDataSourceAlias,
+		name_services.NewNameServicesDNSDataSourceAlias,
+		name_services.NewNameServicesDNSsDataSourceAlias,
+		name_services.NewNameServicesLDAPDataSourceAlias,
+		name_services.NewNameServicesLDAPsDataSourceAlias,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces several new alias functions to simplify the provider implementation and adds corresponding tests for these aliases. The most important changes include the addition of alias functions for DNS and LDAP resources and data sources, and the inclusion of these aliases in the provider's resource and data source lists.
