### PR TITLE
add old name support to security

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -272,6 +272,7 @@ func (p *ONTAPProvider) Resources(ctx context.Context) []func() resource.Resourc
 		protocols.NewProtocolsNfsServiceResourceAlias,
 		protocols.NewProtocolsSanIgroupResourceAlias,
 		protocols.NewProtocolsSanLunMapResourceAlias,
+		security.NewSecurityAccountResourceAlias,
 	}
 }
 
@@ -390,6 +391,8 @@ func (p *ONTAPProvider) DataSources(ctx context.Context) []func() datasource.Dat
 		protocols.NewProtocolsSanIgroupsDataSourceAlias,
 		protocols.NewProtocolsSanLunMapDataSourceAlias,
 		protocols.NewProtocolsSanLunMapsDataSourceAlias,
+		security.NewSecurityAccountDataSourceAlias,
+		security.NewSecurityAccountsDataSourceAlias,
 	}
 }
 

--- a/internal/provider/security/security_account_data_source.go
+++ b/internal/provider/security/security_account_data_source.go
@@ -3,6 +3,7 @@ package security
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,6 +21,15 @@ func NewSecurityAccountDataSource() datasource.DataSource {
 	return &SecurityAccountDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "security_account",
+		},
+	}
+}
+
+// NewSecurityAccountDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSecurityAccountDataSourceAlias() datasource.DataSource {
+	return &SecurityAccountDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "security_account_data_source",
 		},
 	}
 }

--- a/internal/provider/security/security_account_resource.go
+++ b/internal/provider/security/security_account_resource.go
@@ -36,6 +36,15 @@ func NewSecurityAccountResource() resource.Resource {
 	}
 }
 
+// NewSecurityAccountResourceAlias is a helper function to simplify the provider implementation.
+func NewSecurityAccountResourceAlias() resource.Resource {
+	return &SecurityAccountResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "security_account_resource",
+		},
+	}
+}
+
 // SecurityAccountResource defines the resource implementation.
 type SecurityAccountResource struct {
 	config connection.ResourceOrDataSourceConfig

--- a/internal/provider/security/security_account_resource_alias_test.go
+++ b/internal/provider/security/security_account_resource_alias_test.go
@@ -1,0 +1,76 @@
+package security_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+)
+
+func TestAccSecurityAccountResourceAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityAccountResourceConfigAlias("carchitest", "password"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_security_account_resource.security_account", "name", "carchitest"),
+				),
+			},
+			// Test updating a resource
+			{
+				Config: testAccSecurityAccountResourceConfigAlias("carchitest", "password123"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_security_account_resource.security_account", "name", "carchitest"),
+					resource.TestCheckResourceAttr("netapp-ontap_security_account_resource.security_account", "password", "password123"),
+				),
+			},
+			// Test importing a resource
+			{
+				ResourceName:  "netapp-ontap_security_account_resource.security_account",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s", "acc_user", "cluster2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_security_account_resource.security_account", "name", "acc_user"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSecurityAccountResourceConfigAlias(name string, accpassword string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST2")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS2")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster2"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_security_account_resource" "security_account" {
+  # required to know which system to interface with
+  cx_profile_name = "cluster2"
+  name = "%s"
+  applications = [{
+    application = "http"
+    authentication_methods = ["password"]
+  }]
+  password = "%s"
+}
+`, host, admin, password, name, accpassword)
+}

--- a/internal/provider/security/security_accounts_data_source.go
+++ b/internal/provider/security/security_accounts_data_source.go
@@ -3,6 +3,7 @@ package security
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,6 +21,15 @@ func NewSecurityAccountsDataSource() datasource.DataSource {
 	return &SecurityAccountsDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "security_accounts",
+		},
+	}
+}
+
+// NewSecurityAccountsDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSecurityAccountsDataSourceAlias() datasource.DataSource {
+	return &SecurityAccountsDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "security_accounts_data_source",
 		},
 	}
 }


### PR DESCRIPTION
This pull request introduces new alias functions for security-related resources and data sources in the `internal/provider` package, as well as corresponding tests. The most important changes include adding new alias functions to simplify the provider implementation and updating the `Resources` and `DataSources` methods to include these new aliases.
