### PR TITLE
add old name support to Snapmirror

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -273,6 +273,8 @@ func (p *ONTAPProvider) Resources(ctx context.Context) []func() resource.Resourc
 		protocols.NewProtocolsSanIgroupResourceAlias,
 		protocols.NewProtocolsSanLunMapResourceAlias,
 		security.NewSecurityAccountResourceAlias,
+		snapmirror.NewSnapmirrorPolicyResourceAlias,
+		snapmirror.NewSnapmirrorResourceAlias,
 	}
 }
 
@@ -393,6 +395,10 @@ func (p *ONTAPProvider) DataSources(ctx context.Context) []func() datasource.Dat
 		protocols.NewProtocolsSanLunMapsDataSourceAlias,
 		security.NewSecurityAccountDataSourceAlias,
 		security.NewSecurityAccountsDataSourceAlias,
+		snapmirror.NewSnapmirrorDataSourceAlias,
+		snapmirror.NewSnapmirrorPoliciesDataSourceAlias,
+		snapmirror.NewSnapmirrorPolicyDataSourceAlias,
+		snapmirror.NewSnapmirrorsDataSourceAlias,
 	}
 }
 

--- a/internal/provider/snapmirror/snapmirror_data_source.go
+++ b/internal/provider/snapmirror/snapmirror_data_source.go
@@ -3,6 +3,7 @@ package snapmirror
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,6 +22,15 @@ func NewSnapmirrorDataSource() datasource.DataSource {
 	return &SnapmirrorDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "snapmirror",
+		},
+	}
+}
+
+// NewSnapmirrorDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSnapmirrorDataSourceAlias() datasource.DataSource {
+	return &SnapmirrorDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "snapmirror_data_source",
 		},
 	}
 }

--- a/internal/provider/snapmirror/snapmirror_policies_data_source.go
+++ b/internal/provider/snapmirror/snapmirror_policies_data_source.go
@@ -3,8 +3,9 @@ package snapmirror
 import (
 	"context"
 	"fmt"
-	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"strconv"
+
+	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -22,6 +23,15 @@ func NewSnapmirrorPoliciesDataSource() datasource.DataSource {
 	return &SnapmirrorPoliciesDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "snapmirror_policies",
+		},
+	}
+}
+
+// NewSnapmirrorPoliciesDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSnapmirrorPoliciesDataSourceAlias() datasource.DataSource {
+	return &SnapmirrorPoliciesDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "snapmirror_policies_data_source",
 		},
 	}
 }

--- a/internal/provider/snapmirror/snapmirror_policy_data_source.go
+++ b/internal/provider/snapmirror/snapmirror_policy_data_source.go
@@ -3,8 +3,9 @@ package snapmirror
 import (
 	"context"
 	"fmt"
-	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"strconv"
+
+	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -22,6 +23,15 @@ func NewSnapmirrorPolicyDataSource() datasource.DataSource {
 	return &SnapmirrorPolicyDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "snapmirror_policy",
+		},
+	}
+}
+
+// NewSnapmirrorPolicyDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSnapmirrorPolicyDataSourceAlias() datasource.DataSource {
+	return &SnapmirrorPolicyDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "snapmirror_policy_data_source",
 		},
 	}
 }

--- a/internal/provider/snapmirror/snapmirror_policy_resource.go
+++ b/internal/provider/snapmirror/snapmirror_policy_resource.go
@@ -3,9 +3,10 @@ package snapmirror
 import (
 	"context"
 	"fmt"
-	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"strconv"
 	"strings"
+
+	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -34,6 +35,15 @@ func NewSnapmirrorPolicyResource() resource.Resource {
 	return &SnapmirrorPolicyResource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "snapmirror_policy",
+		},
+	}
+}
+
+// NewSnapmirrorPolicyResourceAlias is a helper function to simplify the provider implementation.
+func NewSnapmirrorPolicyResourceAlias() resource.Resource {
+	return &SnapmirrorPolicyResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "snapmirror_policy_resource",
 		},
 	}
 }

--- a/internal/provider/snapmirror/snapmirror_policy_resource_alias_test.go
+++ b/internal/provider/snapmirror/snapmirror_policy_resource_alias_test.go
@@ -1,0 +1,414 @@
+package snapmirror_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccSnapmirrorPolicyResourceAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test snapmirror policy error
+			{
+				Config:      testAccSnapmirrorPolicyResourceBasicConfigAlias("non-existant"),
+				ExpectError: regexp.MustCompile("2621462"),
+			},
+			// Test create snapmirror policy basic
+			{
+				Config: testAccSnapmirrorPolicyResourceBasicConfigAlias("ansibleSVM"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+				),
+			},
+			//  Test adding transfer_schedule
+			{
+				Config: testAccSnapmirrorPolicyResourceAddTransferScheduleBasicConfigAlias("ansibleSVM", "weekly"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "transfer_schedule_name", "weekly"),
+				),
+			},
+			//  Test update transfer_schedule
+			{
+				Config: testAccSnapmirrorPolicyResourceAddTransferScheduleBasicConfigAlias("ansibleSVM", "daily"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "transfer_schedule_name", "daily"),
+				),
+			},
+			// Test remove snapmirror policy transfer schedule
+			{
+				Config: testAccSnapmirrorPolicyResourceBasicConfigAlias("ansibleSVM"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+				),
+			},
+			// Test add snapmirror policy with comment and identity_preservation
+			{
+				Config: testAccSnapmirrorPolicyResourceConfigAlias("ansibleSVM", "test comment", "full"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "comment", "test comment"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "identity_preservation", "full"),
+				),
+			},
+			// Test update snapmirror policy with comment and identity_preservation change
+			{
+				Config: testAccSnapmirrorPolicyResourceConfigAlias("ansibleSVM", "update comment", "exclude_network_config"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "comment", "update comment"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "identity_preservation", "exclude_network_config"),
+				),
+			},
+			// Test update snapmirror policy with adding two retention rules
+			{
+				Config: testAccSnapmirrorPolicyResourceAddTwoRetentionConfigAlias("ansibleSVM", "update comment", "exclude_network_config", "weekly", 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "comment", "update comment"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "identity_preservation", "exclude_network_config"),
+					// check number of reteion
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.#", "2"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.0.label", "hourly"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.0.count", "7"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.1.label", "weekly"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.1.count", "5"),
+				),
+			},
+			// Test update snapmirror policy with removing one retention rule
+			{
+				Config: testAccSnapmirrorPolicyResourceRemoveOneRetentionConfigAlias("ansibleSVM", "update comment", "exclude_network_config"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "name", "carchitestme4"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "comment", "update comment"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "identity_preservation", "exclude_network_config"),
+					// check number of reteion
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.#", "1"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.0.label", "hourly"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.example", "retention.0.count", "7"),
+				),
+			},
+			// Test create sync type snapmirror policy
+			{
+				Config: testAccSnapmirrorPolicyResourceSyncBasicConfigAlias("ansibleSVM", "test sync"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "name", "test_sync"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "comment", "test sync"),
+				),
+			},
+			// Test update sync type snapmirror policy with changing comment
+			{
+				Config: testAccSnapmirrorPolicyResourceSyncBasicConfigAlias("ansibleSVM", "test update sync comment"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "name", "test_sync"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "comment", "test update sync comment"),
+				),
+			},
+			// Test update sync type snapmirror policy with adding a retention
+			{
+				Config: testAccSnapmirrorPolicyResourceSyncAddRetentionConfigAlias("ansibleSVM", "test add retenion in sync type"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "name", "test_sync"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "comment", "test add retenion in sync type"),
+					// check number of reteion
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "retention.#", "1"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "retention.0.label", "daily"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_policy_resource.sync_example", "retention.0.count", "1"),
+				),
+			},
+			// Test update sync type snapmirror policy with adding extra retention - max is 1
+			{
+				Config:      testAccSnapmirrorPolicyResourceSyncAddExtraRetentionConfigAlias("ansibleSVM", "test add extra retenion in sync type"),
+				ExpectError: regexp.MustCompile("error updating sync snapshot policies"),
+			},
+		},
+	})
+}
+
+func testAccSnapmirrorPolicyResourceBasicConfigAlias(svm string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "example" {
+  cx_profile_name = "cluster4"
+  name = "carchitestme4"
+  svm_name = "%s"
+  type = "async"
+}`, host, admin, password, svm)
+}
+
+func testAccSnapmirrorPolicyResourceAddTransferScheduleBasicConfigAlias(svm string, transferScheduleName string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "example" {
+  cx_profile_name = "cluster4"
+  name = "carchitestme4"
+  svm_name = "%s"
+  type = "async"
+  transfer_schedule_name = "%s"
+}`, host, admin, password, svm, transferScheduleName)
+}
+
+func testAccSnapmirrorPolicyResourceConfigAlias(svm string, comment string, identityPreservation string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "example" {
+  cx_profile_name = "cluster4"
+  name = "carchitestme4"
+  svm_name = "%s"
+  comment = "%s"
+  identity_preservation = "%s"
+  type = "async"
+}`, host, admin, password, svm, comment, identityPreservation)
+}
+
+func testAccSnapmirrorPolicyResourceAddTwoRetentionConfigAlias(svm string, comment string, identityPreservation string, label string, count int) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "example" {
+  cx_profile_name = "cluster4"
+  name = "carchitestme4"
+  svm_name = "%s"
+  comment = "%s"
+  identity_preservation = "%s"
+  type = "async"
+  retention = [
+	{
+		label = "hourly"
+		count = 7
+		creation_schedule_name = "hourly"
+	},
+	{
+		label = "%s"
+		count = %d
+	},
+  ]
+}`, host, admin, password, svm, comment, identityPreservation, label, count)
+}
+
+func testAccSnapmirrorPolicyResourceRemoveOneRetentionConfigAlias(svm string, comment string, identityPreservation string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "example" {
+  cx_profile_name = "cluster4"
+  name = "carchitestme4"
+  svm_name = "%s"
+  comment = "%s"
+  identity_preservation = "%s"
+  type = "async"
+  retention = [
+	{
+		label = "hourly"
+		count = 7
+		creation_schedule_name = "hourly"
+	}
+  ]
+}`, host, admin, password, svm, comment, identityPreservation)
+}
+
+func testAccSnapmirrorPolicyResourceSyncBasicConfigAlias(svm string, comment string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "sync_example" {
+  cx_profile_name = "cluster4"
+  name = "test_sync"
+  svm_name = "%s"
+  type = "sync"
+  sync_type = "sync"
+  comment = "%s"
+}`, host, admin, password, svm, comment)
+}
+
+func testAccSnapmirrorPolicyResourceSyncAddRetentionConfigAlias(svm string, comment string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "sync_example" {
+  cx_profile_name = "cluster4"
+  name = "test_sync"
+  svm_name = "%s"
+  type = "sync"
+  sync_type = "sync"
+  comment = "%s"
+  retention = [
+	{
+		label = "daily"
+		count = 1
+	}
+  ]
+}`, host, admin, password, svm, comment)
+}
+
+func testAccSnapmirrorPolicyResourceSyncAddExtraRetentionConfigAlias(svm string, comment string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_policy_resource" "sync_example" {
+  cx_profile_name = "cluster4"
+  name = "test_sync"
+  svm_name = "%s"
+  type = "sync"
+  sync_type = "sync"
+  comment = "%s"
+  retention = [
+	{
+		label = "daily"
+		count = 1
+	},
+	{
+		label = "daily"
+		count = 1
+	}
+  ]
+}`, host, admin, password, svm, comment)
+}

--- a/internal/provider/snapmirror/snapmirror_resource.go
+++ b/internal/provider/snapmirror/snapmirror_resource.go
@@ -3,9 +3,10 @@ package snapmirror
 import (
 	"context"
 	"fmt"
-	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"strings"
 	"time"
+
+	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -30,6 +31,15 @@ func NewSnapmirrorResource() resource.Resource {
 	return &SnapmirrorResource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "snapmirror",
+		},
+	}
+}
+
+// NewSnapmirrorResourceAlias is a helper function to simplify the provider implementation.
+func NewSnapmirrorResourceAlias() resource.Resource {
+	return &SnapmirrorResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "snapmirror_resource",
 		},
 	}
 }

--- a/internal/provider/snapmirror/snapmirror_resource_alias_test.go
+++ b/internal/provider/snapmirror/snapmirror_resource_alias_test.go
@@ -1,0 +1,118 @@
+package snapmirror_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccSnapmirrorResourceAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test non existant Vol
+			{
+				Config:      testAccSnapmirrorResourceBasicConfigAlias("tf_peer:testme", "terraform:testme"),
+				ExpectError: regexp.MustCompile("6619337"),
+			},
+			// Create snapmirror and read
+			{
+				Config: testAccSnapmirrorResourceBasicConfigAlias("tf_peer:snap_source2", "terraform:snap_dest2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_resource.example", "destination_endpoint.path", "terraform:snap_dest2"),
+				),
+			},
+			// Update a policy
+			{
+				Config: testAccSnapmirrorResourceUpdateConfigAlias("tf_peer:snap_source", "terraform:snap_dest", "MirrorAndVault"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_resource.example", "policy.name", "MirrorAndVault"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_resource.example", "destination_endpoint.path", "terraform:snap_dest"),
+				),
+			},
+			// Import and read
+			{
+				ResourceName:  "netapp-ontap_snapmirror_resource.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s", "terraform:snap_dest", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapmirror_resource.example", "destination_endpoint.path", "terraform:snap_dest"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccSnapmirrorResourceBasicConfigAlias(sourceEndpoint string, destinationEndpoint string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST5")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS2")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST5, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS2 must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_resource" "example" {
+  cx_profile_name = "cluster4"
+  source_endpoint = {
+    path = "%s"
+  }
+  destination_endpoint = {
+    path = "%s"
+  }
+}`, host, admin, password, sourceEndpoint, destinationEndpoint)
+}
+
+func testAccSnapmirrorResourceUpdateConfigAlias(sourceEndpoint string, destinationEndpoint string, policy string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST5")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS2")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST5, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS2 must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror_resource" "example" {
+  cx_profile_name = "cluster4"
+  source_endpoint = {
+    path = "%s"
+  }
+  destination_endpoint = {
+    path = "%s"
+  }
+  policy = {
+	name = "%s"
+  }
+}`, host, admin, password, sourceEndpoint, destinationEndpoint, policy)
+}

--- a/internal/provider/snapmirror/snapmirrors_data_source.go
+++ b/internal/provider/snapmirror/snapmirrors_data_source.go
@@ -3,6 +3,7 @@ package snapmirror
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,6 +22,15 @@ func NewSnapmirrorsDataSource() datasource.DataSource {
 	return &SnapmirrorsDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "snapmirrors",
+		},
+	}
+}
+
+// NewSnapmirrorsDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSnapmirrorsDataSourceAlias() datasource.DataSource {
+	return &SnapmirrorsDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "snapmirrors_data_source",
 		},
 	}
 }


### PR DESCRIPTION
This pull request introduces several new SnapMirror resources and data sources to the ONTAP provider, along with corresponding helper functions to simplify the provider implementation. Additionally, it includes a new test file for the SnapMirror resource alias.
