### PR TITLE
Add old name support for SVM

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -281,6 +281,8 @@ func (p *ONTAPProvider) Resources(ctx context.Context) []func() resource.Resourc
 		storage.NewSnapshotPolicyResourceAlias,
 		storage.NewStorageVolumeResourceAlias,
 		storage.NewStorageVolumeSnapshotResourceAlias,
+		svm.NewSVMPeerResourceAlias,
+		svm.NewSvmResourceAlias,
 	}
 }
 
@@ -417,6 +419,10 @@ func (p *ONTAPProvider) DataSources(ctx context.Context) []func() datasource.Dat
 		storage.NewStorageVolumeSnapshotDataSourceAlias,
 		storage.NewStorageVolumeSnapshotsDataSourceAlias,
 		storage.NewStorageVolumesDataSourceAlias,
+		svm.NewSvmDataSourceAlias,
+		svm.NewSVMPeerDataSourceAlias,
+		svm.NewSVMPeersDataSourceAlias,
+		svm.NewSvmsDataSourceAlias,
 	}
 }
 

--- a/internal/provider/svm/svm_data_source.go
+++ b/internal/provider/svm/svm_data_source.go
@@ -3,6 +3,7 @@ package svm
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,6 +22,15 @@ func NewSvmDataSource() datasource.DataSource {
 	return &SvmDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "svm",
+		},
+	}
+}
+
+// NewSvmDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSvmDataSourceAlias() datasource.DataSource {
+	return &SvmDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "svm_data_source",
 		},
 	}
 }

--- a/internal/provider/svm/svm_peer_data_source.go
+++ b/internal/provider/svm/svm_peer_data_source.go
@@ -3,6 +3,7 @@ package svm
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/snapmirror"
 
@@ -22,6 +23,15 @@ func NewSVMPeerDataSource() datasource.DataSource {
 	return &SVMPeerDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "svm_peer",
+		},
+	}
+}
+
+// NewSVMPeerDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSVMPeerDataSourceAlias() datasource.DataSource {
+	return &SVMPeerDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "svm_peer_data_source",
 		},
 	}
 }

--- a/internal/provider/svm/svm_peer_resource.go
+++ b/internal/provider/svm/svm_peer_resource.go
@@ -33,6 +33,15 @@ func NewSVMPeerResource() resource.Resource {
 	}
 }
 
+// NewSVMPeerResourceAlias is a helper function to simplify the provider implementation.
+func NewSVMPeerResourceAlias() resource.Resource {
+	return &SVMPeersResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "svm_peers_resource",
+		},
+	}
+}
+
 // SVMPeersResource defines the resource implementation.
 type SVMPeersResource struct {
 	config connection.ResourceOrDataSourceConfig

--- a/internal/provider/svm/svm_peer_resource_alias_test.go
+++ b/internal/provider/svm/svm_peer_resource_alias_test.go
@@ -1,0 +1,98 @@
+package svm_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccSvmPeerResourceAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test cluster peer non existant to do svm peer
+			{
+				Config:      testAccSvmPeerResourceConfigAlias("testme", "testme2", "abcd", "snapmirror"),
+				ExpectError: regexp.MustCompile("9895941"),
+			},
+			// Testing in VSIM is failing to peer
+			// // Create svm peer and read
+			// {
+			// 	Config: testAccSvmPeersResourceConfig("acc_test_peer2", "acc_test2", "swenjuncluster-1", "snapmirror"),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttr("netapp-ontap_svm_peers_resources.example", "svm.name", "acc_test_peer2"),
+			// 	),
+			// },
+			// // Update applications
+			// {
+			// 	Config: testAccSvmPeersResourceConfig("acc_test_peer2", "acc_test2", "swenjuncluster-1", "flexcache"),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttr("netapp-ontap_svm_peers_resources.example", "applications.0", "flexcache"),
+			// 		resource.TestCheckResourceAttr("netapp-ontap_svm_peers_resources.example", "svm.name", "acc_test_peer2"),
+			// 	),
+			// },
+			// Import and read
+			{
+				ResourceName:  "netapp-ontap_svm_peers_resource.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s,%s", "terraform", "tf_peer", "swenjuncluster-1", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm_peers_resource.example", "svm.name", "snapmirror_dest_dp"),
+				),
+			},
+		},
+	})
+}
+func testAccSvmPeerResourceConfigAlias(svm, peerSvm, peerCluster, applications string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST5")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	password2 := os.Getenv("TF_ACC_NETAPP_PASS2")
+	host2 := os.Getenv("TF_ACC_NETAPP_HOST2")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST2, TF_ACC_NETAPP_HOST5, TF_ACC_NETAPP_USER, TF_ACC_NETAPP_PASS2 and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+	{
+		name = "cluster3"
+		hostname = "%s"
+		username = "%s"
+		password = "%s"
+		validate_certs = false
+	},
+  ]
+}
+
+resource "netapp-ontap_svm_peers_resource" "example" {
+  cx_profile_name = "cluster4"
+  svm = {
+    name = "%s"
+  }
+  peer = {
+    svm = {
+      name = "%s"
+    }
+    cluster = {
+      name = "%s"
+    }
+    peer_cx_profile_name = "cluster3"
+  }
+  applications = ["%s"]
+}`, host, admin, password2, host2, admin, password2, svm, peerSvm, peerCluster, applications)
+}

--- a/internal/provider/svm/svm_peers_data_source.go
+++ b/internal/provider/svm/svm_peers_data_source.go
@@ -3,6 +3,7 @@ package svm
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/snapmirror"
 
@@ -22,6 +23,15 @@ func NewSVMPeersDataSource() datasource.DataSource {
 	return &SVMPeersDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "svm_peers",
+		},
+	}
+}
+
+// NewSVMPeersDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSVMPeersDataSourceAlias() datasource.DataSource {
+	return &SVMPeersDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "svm_peers_data_source",
 		},
 	}
 }

--- a/internal/provider/svm/svm_resource.go
+++ b/internal/provider/svm/svm_resource.go
@@ -3,8 +3,9 @@ package svm
 import (
 	"context"
 	"fmt"
-	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 	"strings"
+
+	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -26,6 +27,15 @@ func NewSvmResource() resource.Resource {
 	return &SvmResource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "svm",
+		},
+	}
+}
+
+// NewSvmResourceAlias is a helper function to simplify the provider implementation.
+func NewSvmResourceAlias() resource.Resource {
+	return &SvmResource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "svm_resource",
 		},
 	}
 }

--- a/internal/provider/svm/svm_resource_alias_test.go
+++ b/internal/provider/svm/svm_resource_alias_test.go
@@ -1,0 +1,123 @@
+package svm_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	ntest "github.com/netapp/terraform-provider-netapp-ontap/internal/provider"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccSvmResourceAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSvmResourceConfigAlias("tfsvm4", "test", "default"),
+				Check: resource.ComposeTestCheckFunc(
+					// Check to see the svm name is correct,
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "name", "tfsvm4"),
+					// Check to see if Ipspace is set correctly
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "ipspace", "ansibleIpspace_newname"),
+					// Check that a ID has been set (we don't know what the vaule is as it changes
+					resource.TestCheckResourceAttrSet("netapp-ontap_svm_resource.example", "id"),
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "comment", "test")),
+			},
+			// Update a comment
+			{
+				Config: testAccSvmResourceConfigAlias("tfsvm4", "carchi8py was here", "default"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "comment", "carchi8py was here"),
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "name", "tfsvm4")),
+			},
+			// Update a comment with an empty string
+			{
+				Config: testAccSvmResourceConfigAlias("tfsvm4", "", "default"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "comment", ""),
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "name", "tfsvm4")),
+			},
+			// Update snapshot policy default-1weekly and comment "carchi8py was here"
+			{
+				Config: testAccSvmResourceConfigAlias("tfsvm4", "carchi8py was here", "default-1weekly"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "comment", "carchi8py was here"),
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "snapshot_policy", "default-1weekly"),
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "name", "tfsvm4")),
+			},
+			// Update snapshot policy with empty string
+			{
+				Config:      testAccSvmResourceConfigAlias("tfsvm4", "carchi8py was here", ""),
+				ExpectError: regexp.MustCompile("cannot be updated with empty string"),
+			},
+			// change SVM name
+			{
+				Config: testAccSvmResourceConfigAlias("tfsvm3", "carchi8py was here", "default"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "comment", "carchi8py was here"),
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "name", "tfsvm3")),
+			},
+			// Fail if the name already exist
+			{
+				Config:      testAccSvmResourceConfigAlias("svm5", "carchi8py was here", "default"),
+				ExpectError: regexp.MustCompile("13434908"),
+			},
+			// Import and read
+			{
+				ResourceName:  "netapp-ontap_svm_resource.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s", "ansibleSVM", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm_resource.example", "name", "ansibleSVM"),
+				),
+			},
+		},
+	})
+}
+func testAccSvmResourceConfigAlias(svm, comment string, snapshotPolicy string) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_svm_resource" "example" {
+  cx_profile_name = "cluster4"
+  name = "%s"
+  ipspace = "ansibleIpspace_newname"
+  comment = "%s"
+  snapshot_policy = "%s"
+  subtype = "default"
+  language = "en_us.utf_8"
+  aggregates = [
+    {
+      name = "aggr1"
+    },
+    {
+      name = "aggr2"
+    },
+    {
+      name = "aggr3"
+    },
+  ]
+  max_volumes = "unlimited"
+}`, host, admin, password, svm, comment, snapshotPolicy)
+}

--- a/internal/provider/svm/svms_data_source.go
+++ b/internal/provider/svm/svms_data_source.go
@@ -3,6 +3,7 @@ package svm
 import (
 	"context"
 	"fmt"
+
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,6 +22,15 @@ func NewSvmsDataSource() datasource.DataSource {
 	return &SvmsDataSource{
 		config: connection.ResourceOrDataSourceConfig{
 			Name: "svms",
+		},
+	}
+}
+
+// NewSvmsDataSourceAlias is a helper function to simplify the provider implementation.
+func NewSvmsDataSourceAlias() datasource.DataSource {
+	return &SvmsDataSource{
+		config: connection.ResourceOrDataSourceConfig{
+			Name: "svms_data_source",
 		},
 	}
 }


### PR DESCRIPTION
This pull request introduces several changes to the `internal/provider` package, primarily focusing on adding new alias functions for resources and data sources, and including new test cases for these aliases. The most important changes are summarized below:
