### PR TITLE
 [Enhancement]: Add SVM `storage_limit` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+# 2.1.0 (2025-02-xx)
+
+ENHANCEMENTS:
+
+- **netapp-ontap_svm**: added `storage.limit` option. ([#302](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/302))
+
 # 2.0.1 (2024-12-13)
 
 Documentation
-* Corrected Resource and Data Source Names
+
+- Corrected Resource and Data Source Names
 
 # 2.0.0 (2024-12-12)
 
@@ -9,320 +16,320 @@ BREAKING CHANGES:
 
 Cluster
 
-* **Rename Resource:** `netapp-ontap_cluster_licensing_license_resource` is now renamed to `netapp-ontap_cluster_licensing_license`
-* **Rename Resource:** `netapp-ontap_cluster_peers_resource` is now renamed to `netapp-ontap_cluster_peer`
-* **Rename Resource:** `netapp-ontap_cluster_schedule_resource` is now renamed to `netapp-ontap_cluster_schedule`
-* **Rename Data Source:** `netapp-ontap_cluster_licensing_license_data_source` is now renamed to `netapp-ontap_cluster_licensing_license`
-* **Rename Data Source:** `netapp-ontap_cluster_licensing_licenses_data_source` is now renamed to `netapp-ontap_cluster_licensing_licenses`
-* **Rename Data Source:** `netapp-ontap_cluster_peer_data_source` is now renamed to `netapp-ontap_cluster_peer`
-* **Rename Data Source:** `netapp-ontap_cluster_peers_data_source` is now renamed to `netapp-ontap_cluster_peers`
-* **Rename Data Source:** `netapp-ontap_cluster_schedule_data_source` is now renamed to `netapp-ontap_cluster_schedule`
-* **Rename Data Source:** `netapp-ontap_cluster_schedules_data_source` is now renamed to `netapp-ontap_cluster_schedules`
+- **Rename Resource:** `netapp-ontap_cluster_licensing_license_resource` is now renamed to `netapp-ontap_cluster_licensing_license`
+- **Rename Resource:** `netapp-ontap_cluster_peers_resource` is now renamed to `netapp-ontap_cluster_peer`
+- **Rename Resource:** `netapp-ontap_cluster_schedule_resource` is now renamed to `netapp-ontap_cluster_schedule`
+- **Rename Data Source:** `netapp-ontap_cluster_licensing_license_data_source` is now renamed to `netapp-ontap_cluster_licensing_license`
+- **Rename Data Source:** `netapp-ontap_cluster_licensing_licenses_data_source` is now renamed to `netapp-ontap_cluster_licensing_licenses`
+- **Rename Data Source:** `netapp-ontap_cluster_peer_data_source` is now renamed to `netapp-ontap_cluster_peer`
+- **Rename Data Source:** `netapp-ontap_cluster_peers_data_source` is now renamed to `netapp-ontap_cluster_peers`
+- **Rename Data Source:** `netapp-ontap_cluster_schedule_data_source` is now renamed to `netapp-ontap_cluster_schedule`
+- **Rename Data Source:** `netapp-ontap_cluster_schedules_data_source` is now renamed to `netapp-ontap_cluster_schedules`
 
 Name Services
 
-* **Rename Resource:** `netapp-ontap_name_services_dns_resource` is now renamed to `netapp-ontap_dns`
-* **Rename Resource:** `netapp-ontap_name_services_ldap_resource` is now renamed to `netapp-ontap_name_services_ldap`
-* **Rename Data Source:** `netapp-ontap_name_services_dns_data_source` is now renamed to `netapp-ontap_dns`
-* **Rename Data Source:** `netapp-ontap_name_services_dnss_data_source` is now renamed to `netapp-ontap_dnss`
-* **Rename Data Source:** `netapp-ontap_name_services_ldap_data_source` is now renamed to `netapp-ontap_name_services_ldap`
-* **Rename Data Source:** `netapp-ontap_name_services_ldaps_data_source` is now renamed to `netapp-ontap_name_services_ldaps`
+- **Rename Resource:** `netapp-ontap_name_services_dns_resource` is now renamed to `netapp-ontap_dns`
+- **Rename Resource:** `netapp-ontap_name_services_ldap_resource` is now renamed to `netapp-ontap_name_services_ldap`
+- **Rename Data Source:** `netapp-ontap_name_services_dns_data_source` is now renamed to `netapp-ontap_dns`
+- **Rename Data Source:** `netapp-ontap_name_services_dnss_data_source` is now renamed to `netapp-ontap_dnss`
+- **Rename Data Source:** `netapp-ontap_name_services_ldap_data_source` is now renamed to `netapp-ontap_name_services_ldap`
+- **Rename Data Source:** `netapp-ontap_name_services_ldaps_data_source` is now renamed to `netapp-ontap_name_services_ldaps`
 
 Networking
 
-* **Rename Resource:** `netapp-ontap_networking_ip_interface_resource` is now renamed to `netapp-ontap_network_ip_interface`
-* **Rename Resource:** `netapp-ontap_networking_ip_route_resource` is now renamed to `netapp-ontap_network_ip_route`
-* **Rename Data Source:** `netapp-ontap_networking_ip_interface_data_source` is now renamed to `netapp-ontap_network_ip_interface`
-* **Rename Data Source:** `netapp-ontap_networking_ip_interfaces_data_source` is now renamed to `netapp-ontap_network_ip_interfaces`
-* **Rename Data Source:** `netapp-ontap_networking_ip_route_data_source` is now renamed to `netapp-ontap_network_ip_route`
-* **Rename Data Source:** `netapp-ontap_networking_ip_routes_data_source` is now renamed to `netapp-ontap_network_ip_routes`
+- **Rename Resource:** `netapp-ontap_networking_ip_interface_resource` is now renamed to `netapp-ontap_network_ip_interface`
+- **Rename Resource:** `netapp-ontap_networking_ip_route_resource` is now renamed to `netapp-ontap_network_ip_route`
+- **Rename Data Source:** `netapp-ontap_networking_ip_interface_data_source` is now renamed to `netapp-ontap_network_ip_interface`
+- **Rename Data Source:** `netapp-ontap_networking_ip_interfaces_data_source` is now renamed to `netapp-ontap_network_ip_interfaces`
+- **Rename Data Source:** `netapp-ontap_networking_ip_route_data_source` is now renamed to `netapp-ontap_network_ip_route`
+- **Rename Data Source:** `netapp-ontap_networking_ip_routes_data_source` is now renamed to `netapp-ontap_network_ip_routes`
 
 Protocols
 
-* **Rename Resource:** `netapp-ontap_cifs_local_group_member_resource` is now renamed to `netapp-ontap_cifs_local_group_members`
-* **Rename Resource:** `netapp-ontap_cifs_local_group_resource` is now renamed to `netapp-ontap_cifs_local_group`
-* **Rename Resource:** `netapp-ontap_cifs_local_user_resource` is now renamed to `netapp-ontap_cifs_local_user`
-* **Rename Resource:** `netapp-ontap_cifs_service_resource` is now renamed to `netapp-ontap_cifs_service`
-* **Rename Resource:** `netapp-ontap_cifs_share_resource` is now renamed to `netapp-ontap_cifs_share`
-* **Rename Resource:** `netapp-ontap_cifs_user_group_privilege_resource` is now renamed to `netapp-ontap_cifs_user_group_privileges`
-* **Rename Resource:** `netapp-ontap_nfs_export_policy_resource` is now renamed to `netapp-ontap_nfs_export_policy`
-* **Rename Resource:** `netapp-ontap_nfs_export_policy_rule_resource` is now renamed to `netapp-ontap_nfs_export_policy_rule`
-* **Rename Resource:** `netapp-ontap_nfs_service_resource` is now renamed to `netapp-ontap_nfs_service`
-* **Rename Resource:** `netapp-ontap_san_igroup_resource` is now renamed to `netapp-ontap_san_igroup`
-* **Rename Resource:** `netapp-ontap_san_lun-maps_resource` is now renamed to `netapp-ontap_san_lun-map`
+- **Rename Resource:** `netapp-ontap_cifs_local_group_member_resource` is now renamed to `netapp-ontap_cifs_local_group_members`
+- **Rename Resource:** `netapp-ontap_cifs_local_group_resource` is now renamed to `netapp-ontap_cifs_local_group`
+- **Rename Resource:** `netapp-ontap_cifs_local_user_resource` is now renamed to `netapp-ontap_cifs_local_user`
+- **Rename Resource:** `netapp-ontap_cifs_service_resource` is now renamed to `netapp-ontap_cifs_service`
+- **Rename Resource:** `netapp-ontap_cifs_share_resource` is now renamed to `netapp-ontap_cifs_share`
+- **Rename Resource:** `netapp-ontap_cifs_user_group_privilege_resource` is now renamed to `netapp-ontap_cifs_user_group_privileges`
+- **Rename Resource:** `netapp-ontap_nfs_export_policy_resource` is now renamed to `netapp-ontap_nfs_export_policy`
+- **Rename Resource:** `netapp-ontap_nfs_export_policy_rule_resource` is now renamed to `netapp-ontap_nfs_export_policy_rule`
+- **Rename Resource:** `netapp-ontap_nfs_service_resource` is now renamed to `netapp-ontap_nfs_service`
+- **Rename Resource:** `netapp-ontap_san_igroup_resource` is now renamed to `netapp-ontap_san_igroup`
+- **Rename Resource:** `netapp-ontap_san_lun-maps_resource` is now renamed to `netapp-ontap_san_lun-map`
 
-* **Rename Data Source:** `netapp-ontap_cifs_local_group_member_data_source` is now renamed to `netapp-ontap_cifs_local_group_member`
-* **Rename Data Source:** `netapp-ontap_cifs_local_group_members_data_source` is now renamed to `netapp-ontap_cifs_local_group_members`
-* **Rename Data Source:** `netapp-ontap_cifs_local_group_data_source` is now renamed to `netapp-ontap_cifs_local_group`
-* **Rename Data Source:** `netapp-ontap_cifs_local_groups_data_source` is now renamed to `netapp-ontap_cifs_local_groups`
-* **Rename Data Source:** `netapp-ontap_cifs_local_user_data_source` is now renamed to `netapp-ontap_cifs_local_user`
-* **Rename Data Source:** `netapp-ontap_cifs_local_users_data_source` is now renamed to `netapp-ontap_cifs_local_users`
-* **Rename Data Source:** `netapp-ontap_cifs_service_data_source` is now renamed to `netapp-ontap_cifs_service`
-* **Rename Data Source:** `netapp-ontap_cifs_services_data_source` is now renamed to `netapp-ontap_cifs_services`
-* **Rename Data Source:** `netapp-ontap_cifs_share_data_source` is now renamed to `netapp-ontap_cifs_share`
-* **Rename Data Source:** `netapp-ontap_cifs_shares_data_source` is now renamed to `netapp-ontap_cifs_shares`
-* **Rename Data Source:** `netapp-ontap_cifs_user_group_privilege_data_source` is now renamed to `netapp-ontap_cifs_user_group_privilege`
-* **Rename Data Source:** `netapp-ontap_cifs_user_group_privileges_data_source` is now renamed to `netapp-ontap_cifs_user_group_privileges`
-* **Rename Data Source:** `netapp-ontap_nfs_export_policy_data_source` is now renamed to `netapp-ontap_nfs_export_policy`
-* **Rename Data Source:** `netapp-ontap_nfs_export_policies_data_source` is now renamed to `netapp-ontap_nfs_export_policies`
-* **Rename Data Source:** `netapp-ontap_nfs_export_policy_rule_data_source` is now renamed to `netapp-ontap_nfs_export_policy_rule`
-* **Rename Data Source:** `netapp-ontap_nfs_export_policy_rules_data_source` is now renamed to `netapp-ontap_nfs_export_policy_rules`
-* **Rename Data Source:** `netapp-ontap_nfs_service_data_source` is now renamed to `netapp-ontap_nfs_service`
-* **Rename Data Source:** `netapp-ontap_nfs_services_data_source` is now renamed to `netapp-ontap_nfs_services`
-* **Rename Data Source:** `netapp-ontap_san_igroup_data_source` is now renamed to `netapp-ontap_san_igroup`
-* **Rename Data Source:** `netapp-ontap_san_igroups_data_source` is now renamed to `netapp-ontap_san_igroups`
-* **Rename Data Source:** `netapp-ontap_san_lun-map_data_source` is now renamed to `netapp-ontap_san_lun-map`
-* **Rename Data Source:** `netapp-ontap_san_lun-maps_data_source` is now renamed to `netapp-ontap_san_lun-maps`
+- **Rename Data Source:** `netapp-ontap_cifs_local_group_member_data_source` is now renamed to `netapp-ontap_cifs_local_group_member`
+- **Rename Data Source:** `netapp-ontap_cifs_local_group_members_data_source` is now renamed to `netapp-ontap_cifs_local_group_members`
+- **Rename Data Source:** `netapp-ontap_cifs_local_group_data_source` is now renamed to `netapp-ontap_cifs_local_group`
+- **Rename Data Source:** `netapp-ontap_cifs_local_groups_data_source` is now renamed to `netapp-ontap_cifs_local_groups`
+- **Rename Data Source:** `netapp-ontap_cifs_local_user_data_source` is now renamed to `netapp-ontap_cifs_local_user`
+- **Rename Data Source:** `netapp-ontap_cifs_local_users_data_source` is now renamed to `netapp-ontap_cifs_local_users`
+- **Rename Data Source:** `netapp-ontap_cifs_service_data_source` is now renamed to `netapp-ontap_cifs_service`
+- **Rename Data Source:** `netapp-ontap_cifs_services_data_source` is now renamed to `netapp-ontap_cifs_services`
+- **Rename Data Source:** `netapp-ontap_cifs_share_data_source` is now renamed to `netapp-ontap_cifs_share`
+- **Rename Data Source:** `netapp-ontap_cifs_shares_data_source` is now renamed to `netapp-ontap_cifs_shares`
+- **Rename Data Source:** `netapp-ontap_cifs_user_group_privilege_data_source` is now renamed to `netapp-ontap_cifs_user_group_privilege`
+- **Rename Data Source:** `netapp-ontap_cifs_user_group_privileges_data_source` is now renamed to `netapp-ontap_cifs_user_group_privileges`
+- **Rename Data Source:** `netapp-ontap_nfs_export_policy_data_source` is now renamed to `netapp-ontap_nfs_export_policy`
+- **Rename Data Source:** `netapp-ontap_nfs_export_policies_data_source` is now renamed to `netapp-ontap_nfs_export_policies`
+- **Rename Data Source:** `netapp-ontap_nfs_export_policy_rule_data_source` is now renamed to `netapp-ontap_nfs_export_policy_rule`
+- **Rename Data Source:** `netapp-ontap_nfs_export_policy_rules_data_source` is now renamed to `netapp-ontap_nfs_export_policy_rules`
+- **Rename Data Source:** `netapp-ontap_nfs_service_data_source` is now renamed to `netapp-ontap_nfs_service`
+- **Rename Data Source:** `netapp-ontap_nfs_services_data_source` is now renamed to `netapp-ontap_nfs_services`
+- **Rename Data Source:** `netapp-ontap_san_igroup_data_source` is now renamed to `netapp-ontap_san_igroup`
+- **Rename Data Source:** `netapp-ontap_san_igroups_data_source` is now renamed to `netapp-ontap_san_igroups`
+- **Rename Data Source:** `netapp-ontap_san_lun-map_data_source` is now renamed to `netapp-ontap_san_lun-map`
+- **Rename Data Source:** `netapp-ontap_san_lun-maps_data_source` is now renamed to `netapp-ontap_san_lun-maps`
 
 Security
 
-* **Rename Resource:** `netapp-ontap_security_accounts_resource` is now renamed to `netapp-ontap_security_account`
-* **Rename Data Source:** `netapp-ontap_security_account_data_source` is now renamed to `netapp-ontap_security_account`
-* **Rename Data Source:** `netapp-ontap_security_accounts_data_source` is now renamed to `netapp-ontap_security_accounts`
+- **Rename Resource:** `netapp-ontap_security_accounts_resource` is now renamed to `netapp-ontap_security_account`
+- **Rename Data Source:** `netapp-ontap_security_account_data_source` is now renamed to `netapp-ontap_security_account`
+- **Rename Data Source:** `netapp-ontap_security_accounts_data_source` is now renamed to `netapp-ontap_security_accounts`
 
 Snapmirror
 
-* **Rename Resource:** `netapp-ontap_snapmirror_resource` is now renamed to `netapp-ontap_snapmirror`
-* **Rename Resource:** `netapp-ontap_snapmirror_policy_resource` is now renamed to `netapp-ontap_snapmirror_policy`
-* **Rename Data Source:** `netapp-ontap_snapmirror_data_source` is now renamed to `netapp-ontap_snapmirror`
-* **Rename Data Source:** `netapp-ontap_snapmirrors_data_source` is now renamed to `netapp-ontap_snapmirrors`
-* **Rename Data Source:** `netapp-ontap_snapmirror_policy_data_source` is now renamed to `netapp-ontap_snapmirror_policy`
-* **Rename Data Source:** `netapp-ontap_snapmirror_policies_data_source` is now renamed to `netapp-ontap_snapmirror_policies`
+- **Rename Resource:** `netapp-ontap_snapmirror_resource` is now renamed to `netapp-ontap_snapmirror`
+- **Rename Resource:** `netapp-ontap_snapmirror_policy_resource` is now renamed to `netapp-ontap_snapmirror_policy`
+- **Rename Data Source:** `netapp-ontap_snapmirror_data_source` is now renamed to `netapp-ontap_snapmirror`
+- **Rename Data Source:** `netapp-ontap_snapmirrors_data_source` is now renamed to `netapp-ontap_snapmirrors`
+- **Rename Data Source:** `netapp-ontap_snapmirror_policy_data_source` is now renamed to `netapp-ontap_snapmirror_policy`
+- **Rename Data Source:** `netapp-ontap_snapmirror_policies_data_source` is now renamed to `netapp-ontap_snapmirror_policies`
 
 Storage
 
-* **Rename Resource:** `netapp-ontap_aggregate_resource` is now renamed to `netapp-ontap_aggregate`
-* **Rename Resource:** `netapp-ontap_flexcache_resource` is now renamed to `netapp-ontap_flexcache`
-* **Rename Resource:** `netapp-ontap_lun_resource` is now renamed to `netapp-ontap_lun`
-* **Rename Resource:** `netapp-ontap_snapshot_policy_resource` is now renamed to `netapp-ontap_snapshot_policy`
-* **Rename Resource:** `netapp-ontap_volume_resource` is now renamed to `netapp-ontap_volume`
-* **Rename Resource:** `netapp-ontap_volume_snapshot_resource` is now renamed to `netapp-ontap_volume_snapshot`
+- **Rename Resource:** `netapp-ontap_aggregate_resource` is now renamed to `netapp-ontap_aggregate`
+- **Rename Resource:** `netapp-ontap_flexcache_resource` is now renamed to `netapp-ontap_flexcache`
+- **Rename Resource:** `netapp-ontap_lun_resource` is now renamed to `netapp-ontap_lun`
+- **Rename Resource:** `netapp-ontap_snapshot_policy_resource` is now renamed to `netapp-ontap_snapshot_policy`
+- **Rename Resource:** `netapp-ontap_volume_resource` is now renamed to `netapp-ontap_volume`
+- **Rename Resource:** `netapp-ontap_volume_snapshot_resource` is now renamed to `netapp-ontap_volume_snapshot`
 
-* **Rename Data Source:** `netapp-ontap_aggregate_data_source` is now renamed to `netapp-ontap_aggregate`
-* **Rename Data Source:** `netapp-ontap_aggregates_data_source` is now renamed to `netapp-ontap_aggregates`
-* **Rename Data Source:** `netapp-ontap_flexcache_data_source` is now renamed to `netapp-ontap_flexcache`
-* **Rename Data Source:** `netapp-ontap_flexcaches_data_source` is now renamed to `netapp-ontap_flexcaches`
-* **Rename Data Source:** `netapp-ontap_lun_data_source` is now renamed to `netapp-ontap_lun`
-* **Rename Data Source:** `netapp-ontap_luns_data_source` is now renamed to `netapp-ontap_luns`
-* **Rename Data Source:** `netapp-ontap_snapshot_policy_data_source` is now renamed to `netapp-ontap_snapshot_policy`
-* **Rename Data Source:** `netapp-ontap_snapshot_policies_data_source` is now renamed to `netapp-ontap_snapshot_policies`
-* **Rename Data Source:** `netapp-ontap_volume_data_source` is now renamed to `netapp-ontap_volume`
-* **Rename Data Source:** `netapp-ontap_volumes_data_source` is now renamed to `netapp-ontap_volumes`
-* **Rename Data Source:** `netapp-ontap_volume_snapshot_data_source` is now renamed to `netapp-ontap_volume_snapshot`
-* **Rename Data Source:** `netapp-ontap_volume_snapshots_data_source` is now renamed to `netapp-ontap_volume_snapshots`
+- **Rename Data Source:** `netapp-ontap_aggregate_data_source` is now renamed to `netapp-ontap_aggregate`
+- **Rename Data Source:** `netapp-ontap_aggregates_data_source` is now renamed to `netapp-ontap_aggregates`
+- **Rename Data Source:** `netapp-ontap_flexcache_data_source` is now renamed to `netapp-ontap_flexcache`
+- **Rename Data Source:** `netapp-ontap_flexcaches_data_source` is now renamed to `netapp-ontap_flexcaches`
+- **Rename Data Source:** `netapp-ontap_lun_data_source` is now renamed to `netapp-ontap_lun`
+- **Rename Data Source:** `netapp-ontap_luns_data_source` is now renamed to `netapp-ontap_luns`
+- **Rename Data Source:** `netapp-ontap_snapshot_policy_data_source` is now renamed to `netapp-ontap_snapshot_policy`
+- **Rename Data Source:** `netapp-ontap_snapshot_policies_data_source` is now renamed to `netapp-ontap_snapshot_policies`
+- **Rename Data Source:** `netapp-ontap_volume_data_source` is now renamed to `netapp-ontap_volume`
+- **Rename Data Source:** `netapp-ontap_volumes_data_source` is now renamed to `netapp-ontap_volumes`
+- **Rename Data Source:** `netapp-ontap_volume_snapshot_data_source` is now renamed to `netapp-ontap_volume_snapshot`
+- **Rename Data Source:** `netapp-ontap_volume_snapshots_data_source` is now renamed to `netapp-ontap_volume_snapshots`
 
 Svm
 
-* **Rename Resource:** `netapp-ontap_svm_peers_resource` is now renamed to `netapp-ontap_svm_peer`
-* **Rename Resource:** `netapp-ontap_svm_resource` is now renamed to `netapp-ontap_svm`
-* **Rename Data Source:** `netapp-ontap_svm_peer_data_source` is now renamed to `netapp-ontap_svm_peer`
-* **Rename Data Source:** `netapp-ontap_svm_peers_data_source` is now renamed to `netapp-ontap_svm_peers`
-* **Rename Data Source:** `netapp-ontap_svm_data_source` is now renamed to `netapp-ontap_svm`
-* **Rename Data Source:** `netapp-ontap_svms_data_source` is now renamed to `netapp-ontap_svms`
+- **Rename Resource:** `netapp-ontap_svm_peers_resource` is now renamed to `netapp-ontap_svm_peer`
+- **Rename Resource:** `netapp-ontap_svm_resource` is now renamed to `netapp-ontap_svm`
+- **Rename Data Source:** `netapp-ontap_svm_peer_data_source` is now renamed to `netapp-ontap_svm_peer`
+- **Rename Data Source:** `netapp-ontap_svm_peers_data_source` is now renamed to `netapp-ontap_svm_peers`
+- **Rename Data Source:** `netapp-ontap_svm_data_source` is now renamed to `netapp-ontap_svm`
+- **Rename Data Source:** `netapp-ontap_svms_data_source` is now renamed to `netapp-ontap_svms`
 
 FEATURES:
 
-* **provider**: add `aws_lambda` option. ([#262](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/262))
-* **New Data Source:** `netapp-ontap_volume_file` ([#8](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/8))
-* **New Data Source:** `netapp-ontap_qos_policy` ([#77](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/77))
-* **New Data Source:** `netapp-ontap_qos_policies` ([#77](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/77))
-* **New Data Source:** `netapp-ontap_quota_rules` ([#135](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/135))
-* **New Data Source:** `netapp-ontap_quota_rule` ([#135](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/135))
-* **New Data Source:** `netapp-ontap_security_role` ([#139](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/139))
-* **New Data Source:** `netapp-ontap_security_roles` ([#139](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/139))
-* **New Data Source:** `netapp-ontap_security_login_message` ([#17](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/17))
-* **New Data Source:** `netapp-ontap_security_login_messages` ([#17](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/17))
-* **New Data Source:** `netapp-ontap_qtree` ([#83](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/83))
-* **New Data Source:** `netapp-ontap_qtrees` ([#83](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/83))
-* **New Data Source:** `netapp-ontap_volume_efficiency_policy` ([#81](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/81))
-* **New Data Source:** `netapp-ontap_volume_efficiency_policies` ([#81](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/81))
-* **New Data Source:** `netapp-ontap_security_certificate` ([#137](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/137))
-* **New Data Source:** `netapp-ontap_security_certificates` ([#137](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/137))
-* **New Resource:** `netapp-ontap_volume_efficiency_policy` ([#80](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/80))
-* **New Resource:** `netapp-ontap_quota_rule` ([#136](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/136))
-* **New Resource:** `netapp-ontap_volume_file` ([#5](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/5))
-* **New Resource:** `netapp-ontap_security_role` ([#140](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/140))
-* **New Resource:** `netapp-ontap_qtree` ([#82](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/82))
-* **New Resource:** `netapp-ontap_qos_policy` ([#76](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/76))
-* **New Resource:** `netapp-security_login_message` ([#18](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/18))
-* **New Resource:** `netapp-ontap_security_certificate` ([#138](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/138))
+- **provider**: add `aws_lambda` option. ([#262](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/262))
+- **New Data Source:** `netapp-ontap_volume_file` ([#8](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/8))
+- **New Data Source:** `netapp-ontap_qos_policy` ([#77](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/77))
+- **New Data Source:** `netapp-ontap_qos_policies` ([#77](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/77))
+- **New Data Source:** `netapp-ontap_quota_rules` ([#135](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/135))
+- **New Data Source:** `netapp-ontap_quota_rule` ([#135](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/135))
+- **New Data Source:** `netapp-ontap_security_role` ([#139](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/139))
+- **New Data Source:** `netapp-ontap_security_roles` ([#139](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/139))
+- **New Data Source:** `netapp-ontap_security_login_message` ([#17](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/17))
+- **New Data Source:** `netapp-ontap_security_login_messages` ([#17](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/17))
+- **New Data Source:** `netapp-ontap_qtree` ([#83](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/83))
+- **New Data Source:** `netapp-ontap_qtrees` ([#83](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/83))
+- **New Data Source:** `netapp-ontap_volume_efficiency_policy` ([#81](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/81))
+- **New Data Source:** `netapp-ontap_volume_efficiency_policies` ([#81](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/81))
+- **New Data Source:** `netapp-ontap_security_certificate` ([#137](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/137))
+- **New Data Source:** `netapp-ontap_security_certificates` ([#137](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/137))
+- **New Resource:** `netapp-ontap_volume_efficiency_policy` ([#80](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/80))
+- **New Resource:** `netapp-ontap_quota_rule` ([#136](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/136))
+- **New Resource:** `netapp-ontap_volume_file` ([#5](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/5))
+- **New Resource:** `netapp-ontap_security_role` ([#140](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/140))
+- **New Resource:** `netapp-ontap_qtree` ([#82](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/82))
+- **New Resource:** `netapp-ontap_qos_policy` ([#76](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/76))
+- **New Resource:** `netapp-security_login_message` ([#18](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/18))
+- **New Resource:** `netapp-ontap_security_certificate` ([#138](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/138))
 
 ENHANCEMENTS:
 
-* **netapp-ontap_lun**: added `size_unit` option. ([#227](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/227))
-* **netapp-ontap_security_account**: Add support for import and update ([#243](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/243))
-* **netapp-ontap_name_services_dns**: Add `skip_config_validation`([#316](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/316))
+- **netapp-ontap_lun**: added `size_unit` option. ([#227](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/227))
+- **netapp-ontap_security_account**: Add support for import and update ([#243](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/243))
+- **netapp-ontap_name_services_dns**: Add `skip_config_validation`([#316](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/316))
 
 ## 1.1.4 (2024-09-05)
 
 DOC FIXES:
 
-* **netapp-ontap_storage_flexcache_resource**: Fixed Page display issue ([[#271](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/271)])
-* **netapp-ontap_networking_ip_interface_resource**: Include min version for metrics ([[#265](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/265)])
-* Fix the documentation: snapmirror and the description of other data source and resource ([[#330](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/330)])
+- **netapp-ontap_storage_flexcache_resource**: Fixed Page display issue ([[#271](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/271)])
+- **netapp-ontap_networking_ip_interface_resource**: Include min version for metrics ([[#265](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/265)])
+- Fix the documentation: snapmirror and the description of other data source and resource ([[#330](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/330)])
 
 BUG FIXES:
 
-* **netapp-ontap_cluster_data_source**: fix on nodes to show multiple elements ([#264](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/264))
-* **netapp-ontap_protocols_nfs_export_policy_resource**: fix id error during the creation ([[#290](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/290)])
+- **netapp-ontap_cluster_data_source**: fix on nodes to show multiple elements ([#264](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/264))
+- **netapp-ontap_protocols_nfs_export_policy_resource**: fix id error during the creation ([[#290](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/290)])
 
 ## 1.1.3 (2024-08-08)
 
 BUG FIXES:
 
-* **netapp-ontap_protocols_cifs_service_resource**: fixed on attribute checking ([#250](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/250))
-* **netapp-ontap_protocols_cifs_share_resource** :`acls` unable to update acls ([#236](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/236))
-* **netapp-ontap_protocols_san_igroups_resource**: fixed bug nil pointer dereference ([#247](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/247))
+- **netapp-ontap_protocols_cifs_service_resource**: fixed on attribute checking ([#250](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/250))
+- **netapp-ontap_protocols_cifs_share_resource** :`acls` unable to update acls ([#236](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/236))
+- **netapp-ontap_protocols_san_igroups_resource**: fixed bug nil pointer dereference ([#247](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/247))
 
 ## 1.1.2 (2024-06-03)
 
 ENHANCEMENTS:
 
-* **netapp-ontap_storage_lun_resource**, **netapp-ontap_storage_lun_data_source**, **netapp-ontap_storage_luns_data_source**: added `serial_number` option to get info in state file ([#207](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/207))
+- **netapp-ontap_storage_lun_resource**, **netapp-ontap_storage_lun_data_source**, **netapp-ontap_storage_luns_data_source**: added `serial_number` option to get info in state file ([#207](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/207))
 
 BUG FIXES:
 
-* **netapp-ontap_storage_lun_resource**, **netapp-ontap_storage_lun_data_source**, **netapp-ontap_storage_luns_data_source**: fixed `name` and `logical_unit` options as separate inputs for resource and info in state file gets added separately as well ([#215](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/215))
-* added guide for changing NetApp Ontap Provider from one minor version to another.
-* corrected typos in the CHANGELOG.
+- **netapp-ontap_storage_lun_resource**, **netapp-ontap_storage_lun_data_source**, **netapp-ontap_storage_luns_data_source**: fixed `name` and `logical_unit` options as separate inputs for resource and info in state file gets added separately as well ([#215](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/215))
+- added guide for changing NetApp Ontap Provider from one minor version to another.
+- corrected typos in the CHANGELOG.
 
 BUG FIXES:
 
-* **netapp-ontap_storage_flexcache_resource**: Fixed junction_path bug ([#223](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/223))
+- **netapp-ontap_storage_flexcache_resource**: Fixed junction_path bug ([#223](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/223))
 
 ## 1.1.1 (2024-05-15)
 
-* added missing resources in changelog.
-* corrected typos in the documentation.
+- added missing resources in changelog.
+- corrected typos in the documentation.
 
 ## 1.1.0 (2024-05-08)
 
 FEATURES:
 
-* **New Data Source:** `netapp-ontap_protocols_cifs_local_group_data_source` ([#54](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/54))
-* **New Data Source:** `netapp-ontap_protocols_cifs_local_groups_data_source` ([#54](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/54))
-* **New Data Source:** `netapp-ontap_cluster_peer_data_source` ([#50](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/50))
-* **New Data Source:** `netapp-ontap_cluster_peers_data_source` ([#50](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/50))
-* **New Data Source:** `netapp-ontap_protocols_cifs_local_user_data_source` ([#55](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/55))
-* **New Data Source:** `netapp-ontap_protocols_cifs_local_users_data_source` ([#55](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/55))
-* **New Data Source:** `netapp-ontap_security_account_data_source` ([#22](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/22))
-* **New Data Source:** `netapp-ontap_security_accounts_data_source` ([#22](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/22))
-* **New Data Source:** `netapp-ontap_protocols_cifs_user_group_privilege_data_source` ([#57](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/57))
-* **New Data Source:** `netapp-ontap_protocols_cifs_user_group_privileges_data_source` ([#57](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/57))
-* **New Data Source:** `netapp-ontap_storage_lun_data_source` ([#12](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/12))
-* **New Data Source:** `netapp-ontap_storage_luns_data_source` ([#12](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/12))
-* **New Data Source:** `netapp-ontap_protocols_cifs_local_group_member_data_source` ([#122](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/122))
-* **New Data Source:** `netapp-ontap_protocols_cifs_local_group_members_data_source` ([#122](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/122))
-* **New Data Source:** `netapp-ontap_svm_peer_data_source` ([#52](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/52))
-* **New Data Source:** `netapp-ontap_svm_peers_data_source` ([#52](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/52))
-* **New Data Source:** `netapp-ontap_protocols_cifs_server_data_source` ([#24](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/24))
-* **New Data Source:** `netapp-ontap_protocols_cifs_servers_data_source` ([#24](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/24))
-* **New Data Source:** `netapp-ontap_storage_flexcache_data_source` ([#47](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/47))
-* **New Data Source:** `netapp-ontap_storage_flexcaches_data_source` ([#47](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/47))
-* **New Data Source:** `netapp-ontap_name_services_ldap_data_source` ([#26](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/26))
-* **New Data Source:** `netapp-ontap_name_services_ldaps_data_source` ([#26](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/26))
-* **New Data Source:** `netapp-ontap_protocols_cifs_share_data_source` ([#28](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/28))
-* **New Data Source:** `netapp-ontap_protocols_cifs_shares_data_source` ([#28](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/28))
-* **New Data Source:** `netapp-ontap_protocols_san_lun-map_data_source` ([#14](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/14))
-* **New Data Source:** `netapp-ontap_protocols_san_lun-maps_data_source` ([#14](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/14))
-* **New Resource:** `netapp-ontap_protocols_cifs_local_group_resource` ([#53](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/53))
-* **New Resource:** `netapp-ontap_protocols_cifs_local_user_resource` ([#56](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/56))
-* **New Resource:** `netapp-ontap_protocols_cifs_user_group_privilege_resource` ([#58](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/58))
-* **New Resource:** `netapp-ontap_svm_peers_resource` ([#51](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/51))
-* **New Resource:** `netapp-ontap_protocols_cifs_user_group_member_resource` ([#123](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/123))
-* **New Resource:** `netapp-ontap_storage_flexcache_resource` ([#46](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/46))
-* **New Resource:** `netapp-ontap_protocols_san_lun-maps_resource` ([#13](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/13))
-* **New Resource:** `netapp-ontap_name_services_ldap_resource` ([#25](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/25))
-* **New Resource:** `netapp-ontap_protocols_cifs_service_resource` ([#23](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/23))
-* **New Resource:** `netapp-ontap_protocols_cifs_share_resource` ([#27](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/27))
-* **New Resource:** `netapp-ontap_protocols_san_igroup_resource` ([#9](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/9))
-* **New Resource:** `netapp-ontap_cluster_resource` ([#15](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/15))
-* **New Resource:** `netapp-ontap_cluster_peers_resource` ([#49](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/49))
-* **New Resource:** `netapp-ontap_storage_lun_resource` ([#11](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/11))
-* **New Resource:** `netapp-ontap_security_account_resource` ([#21](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/21))
+- **New Data Source:** `netapp-ontap_protocols_cifs_local_group_data_source` ([#54](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/54))
+- **New Data Source:** `netapp-ontap_protocols_cifs_local_groups_data_source` ([#54](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/54))
+- **New Data Source:** `netapp-ontap_cluster_peer_data_source` ([#50](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/50))
+- **New Data Source:** `netapp-ontap_cluster_peers_data_source` ([#50](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/50))
+- **New Data Source:** `netapp-ontap_protocols_cifs_local_user_data_source` ([#55](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/55))
+- **New Data Source:** `netapp-ontap_protocols_cifs_local_users_data_source` ([#55](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/55))
+- **New Data Source:** `netapp-ontap_security_account_data_source` ([#22](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/22))
+- **New Data Source:** `netapp-ontap_security_accounts_data_source` ([#22](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/22))
+- **New Data Source:** `netapp-ontap_protocols_cifs_user_group_privilege_data_source` ([#57](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/57))
+- **New Data Source:** `netapp-ontap_protocols_cifs_user_group_privileges_data_source` ([#57](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/57))
+- **New Data Source:** `netapp-ontap_storage_lun_data_source` ([#12](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/12))
+- **New Data Source:** `netapp-ontap_storage_luns_data_source` ([#12](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/12))
+- **New Data Source:** `netapp-ontap_protocols_cifs_local_group_member_data_source` ([#122](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/122))
+- **New Data Source:** `netapp-ontap_protocols_cifs_local_group_members_data_source` ([#122](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/122))
+- **New Data Source:** `netapp-ontap_svm_peer_data_source` ([#52](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/52))
+- **New Data Source:** `netapp-ontap_svm_peers_data_source` ([#52](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/52))
+- **New Data Source:** `netapp-ontap_protocols_cifs_server_data_source` ([#24](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/24))
+- **New Data Source:** `netapp-ontap_protocols_cifs_servers_data_source` ([#24](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/24))
+- **New Data Source:** `netapp-ontap_storage_flexcache_data_source` ([#47](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/47))
+- **New Data Source:** `netapp-ontap_storage_flexcaches_data_source` ([#47](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/47))
+- **New Data Source:** `netapp-ontap_name_services_ldap_data_source` ([#26](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/26))
+- **New Data Source:** `netapp-ontap_name_services_ldaps_data_source` ([#26](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/26))
+- **New Data Source:** `netapp-ontap_protocols_cifs_share_data_source` ([#28](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/28))
+- **New Data Source:** `netapp-ontap_protocols_cifs_shares_data_source` ([#28](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/28))
+- **New Data Source:** `netapp-ontap_protocols_san_lun-map_data_source` ([#14](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/14))
+- **New Data Source:** `netapp-ontap_protocols_san_lun-maps_data_source` ([#14](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/14))
+- **New Resource:** `netapp-ontap_protocols_cifs_local_group_resource` ([#53](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/53))
+- **New Resource:** `netapp-ontap_protocols_cifs_local_user_resource` ([#56](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/56))
+- **New Resource:** `netapp-ontap_protocols_cifs_user_group_privilege_resource` ([#58](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/58))
+- **New Resource:** `netapp-ontap_svm_peers_resource` ([#51](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/51))
+- **New Resource:** `netapp-ontap_protocols_cifs_user_group_member_resource` ([#123](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/123))
+- **New Resource:** `netapp-ontap_storage_flexcache_resource` ([#46](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/46))
+- **New Resource:** `netapp-ontap_protocols_san_lun-maps_resource` ([#13](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/13))
+- **New Resource:** `netapp-ontap_name_services_ldap_resource` ([#25](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/25))
+- **New Resource:** `netapp-ontap_protocols_cifs_service_resource` ([#23](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/23))
+- **New Resource:** `netapp-ontap_protocols_cifs_share_resource` ([#27](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/27))
+- **New Resource:** `netapp-ontap_protocols_san_igroup_resource` ([#9](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/9))
+- **New Resource:** `netapp-ontap_cluster_resource` ([#15](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/15))
+- **New Resource:** `netapp-ontap_cluster_peers_resource` ([#49](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/49))
+- **New Resource:** `netapp-ontap_storage_lun_resource` ([#11](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/11))
+- **New Resource:** `netapp-ontap_security_account_resource` ([#21](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/21))
 
 ENHANCEMENTS:
 
-* **netapp-ontap_protocols_nfs_export_policy_resource**: Add support for import ([#34](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/34))
-* **netapp-ontap_cluster_licensing_license_resource**: Add support for import ([#30](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/30))
-* **netapp-ontap_storage_aggregate_resource**: Add support for import ([#39](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/39))
-* **netapp-ontap_storage_volume_resource**: Add support for import ([#41](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/41))
-* **netapp-ontap_protocols_nfs_service_resource**: Add support for import ([#36](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/36))
-* **netapp-ontap_svm_resource**: Add support for import ([#6](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/6))
-* **netapp-ontap_storage_volume_snapshot_resource**: Add support for import ([#42](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/42))
-* **netapp-ontap_cluster_schedule_resource**: Add support for import ([#31](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/31))
-* **netapp-ontap_storage_snapshot_policy_resource**: Add support for import ([#40](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/40))
-* **netapp-ontap_snapmirror_resource**: Add support for modify ([#45](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/45))
-* **netapp-ontap_snapmirror_resource**: Add support for import ([#37](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/37))
-* **netapp-ontap_snapmirror_policy**: Add support for import ([#38](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/38))
-* **netapp-ontap_networking_ip_interface_resource**: Add support for import ([#32](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/32))
-* **netapp-ontap_protocols_nfs_export_policy_rule_resource**: Add support for import ([#35](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/35))
-* **netapp-ontap_networking_ip_route_resource**: Add support for import ([#33](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/33))
-* **netapp-ontap_cluster** Add contact, locaton, dns_domains, name_servers, timezone, certificate, ntp_servers, management_interfaces options ([#16](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/16))
+- **netapp-ontap_protocols_nfs_export_policy_resource**: Add support for import ([#34](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/34))
+- **netapp-ontap_cluster_licensing_license_resource**: Add support for import ([#30](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/30))
+- **netapp-ontap_storage_aggregate_resource**: Add support for import ([#39](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/39))
+- **netapp-ontap_storage_volume_resource**: Add support for import ([#41](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/41))
+- **netapp-ontap_protocols_nfs_service_resource**: Add support for import ([#36](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/36))
+- **netapp-ontap_svm_resource**: Add support for import ([#6](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/6))
+- **netapp-ontap_storage_volume_snapshot_resource**: Add support for import ([#42](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/42))
+- **netapp-ontap_cluster_schedule_resource**: Add support for import ([#31](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/31))
+- **netapp-ontap_storage_snapshot_policy_resource**: Add support for import ([#40](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/40))
+- **netapp-ontap_snapmirror_resource**: Add support for modify ([#45](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/45))
+- **netapp-ontap_snapmirror_resource**: Add support for import ([#37](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/37))
+- **netapp-ontap_snapmirror_policy**: Add support for import ([#38](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/38))
+- **netapp-ontap_networking_ip_interface_resource**: Add support for import ([#32](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/32))
+- **netapp-ontap_protocols_nfs_export_policy_rule_resource**: Add support for import ([#35](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/35))
+- **netapp-ontap_networking_ip_route_resource**: Add support for import ([#33](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/33))
+- **netapp-ontap_cluster** Add contact, locaton, dns_domains, name_servers, timezone, certificate, ntp_servers, management_interfaces options ([#16](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/16))
 
 BUG FIXES:
 
-* **netapp-ontap_protocols_nfs_service**: Fixed issue with version check failing for minor versions
-* netapp-ontap resource and data source documentation update ([#169](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/169))
+- **netapp-ontap_protocols_nfs_service**: Fixed issue with version check failing for minor versions
+- netapp-ontap resource and data source documentation update ([#169](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/169))
 
 ## 1.0.3 (2023-12-05)
 
-* netapp-ontap_name_services_dns_resource: Fixed missing ID on create ([#99](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/63))
+- netapp-ontap_name_services_dns_resource: Fixed missing ID on create ([#99](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/63))
 
 ## 1.0.2 (2023-11-17)
 
-* 1.0.1 did not deploy correctly 1.0.2 fixes that. 
+- 1.0.1 did not deploy correctly 1.0.2 fixes that.
 
 ## 1.0.1 (2023-11-17)
 
 BUG FIXES:
 
-* **netapp-ontap_name_services_dns_resource**: Fixed and Documented Import ([#63](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/63))
-* **netapp-ontap_cluster_data_source**, **netapp-ontap_snapmirrors_data_source**, **netapp-ontap_networking_ip_route_resource** and **netapp-ontap_sotrage_volume_resource**: Fix documentation ([#70](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/70))
-* **netapp-ontap_name_services_ldap_resource**: Fixed and Document with the version check and workflow ([#163](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/163))
+- **netapp-ontap_name_services_dns_resource**: Fixed and Documented Import ([#63](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/63))
+- **netapp-ontap_cluster_data_source**, **netapp-ontap_snapmirrors_data_source**, **netapp-ontap_networking_ip_route_resource** and **netapp-ontap_sotrage_volume_resource**: Fix documentation ([#70](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/70))
+- **netapp-ontap_name_services_ldap_resource**: Fixed and Document with the version check and workflow ([#163](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/163))
 
 ## 1.0.0 (2023-11-06)
 
 FEATURES:
 
-* **New Data Source:** `netapp-ontap_cluster_data_source`
-* **New Data Source:** `netapp-ontap_cluster_licensing_license_data_source`
-* **New Data Source:** `netapp-ontap_cluster_licensing_licenses_data_source`
-* **New Data Source:** `netapp-ontap_cluster_schedule_data_source`
-* **New Data Source:** `netapp-ontap_cluster_schedules_data_source`
-* **New Data Source:** `netapp-ontap_ip_interface_data_source`
-* **New Data Source:** `netapp-ontap_ip_interfaces_data_source`
-* **New Data Source:** `netapp-ontap_name_services_dns_data_source`
-* **New Data Source:** `netapp-ontap_name_services_dnss_data_source`
-* **New Data Source:** `netapp-ontap_networking_ip_route_data_source`
-* **New Data Source:** `netapp-ontap_networking_ip_routes_data_source`
-* **New Data Source:** `netapp-ontap_protcols_nfs_service_data_source`
-* **New Data Source:** `netapp-ontap_protcols_nfs_services_data_source`
-* **New Data Source:** `netapp-ontap_protocols_nfs_export_policies_data_source`
-* **New Data Source:** `netapp-ontap_protocols_nfs_export_policy_data_source`
-* **New Data Source:** `netapp-ontap_protocols_nfs_export_policy_rule_data_source`
-* **New Data Source:** `netapp-ontap_snapmirror_policies_data_source`
-* **New Data Source:** `netapp-ontap_snapmirror_policy_data_source`
-* **New Data Source:** `netapp-ontap_storage_aggregate_data_source`
-* **New Data Source:** `netapp-ontap_storage_aggregates_data_source`
-* **New Data Source:** `netapp-ontap_storage_snapshot_policies_data_source`
-* **New Data Source:** `netapp-ontap_storage_snapshot_policy_data_source`
-* **New Data Source:** `netapp-ontap_storage_volume_data_source`
-* **New Data Source:** `netapp-ontap_storage_volumes_data_source`
-* **New Data Source:** `netapp-ontap_storage_volume_snapshot_data_source`
-* **New Data Source:** `netapp-ontap_svm_data_source`
-* **New Data Source:** `netapp-ontap_svms_data_source`
-* **New Resource:** `netapp-ontap_cluster_licensing_license_resource`
-* **New Resource:** `netapp-ontap_cluster_schedule_resource`
-* **New Resource:** `netapp-ontap_networking_ip_interface_resource`
-* **New Resource:** `netapp-ontap_name_services_dns_resource`
-* **New Resource:** `netapp-ontap_networking_ip_route_resource`
-* **New Resource:** `netapp-ontap_protocols_nfs_export_policy_resource`
-* **New Resource:** `netapp-ontap_protocols_nfs_export_policy_rule_resource`
-* **New Resource:** `netapp-ontap_snapmirror_resource`
-* **New Resource:** `netapp-ontap_snapmirror_policy_resource`
-* **New Resource:** `netapp-ontap_storage_aggregate_resource`
-* **New Resource:** `netapp-ontap_storage_snapshot_policy_resource`
-* **New Resource:** `netapp-ontap_storage_volume_resource`
-* **New Resource:** `netapp-ontap_storage_volume_snapshot_resource`
-* **New Resource:** `netapp-ontap_svm_resource`
+- **New Data Source:** `netapp-ontap_cluster_data_source`
+- **New Data Source:** `netapp-ontap_cluster_licensing_license_data_source`
+- **New Data Source:** `netapp-ontap_cluster_licensing_licenses_data_source`
+- **New Data Source:** `netapp-ontap_cluster_schedule_data_source`
+- **New Data Source:** `netapp-ontap_cluster_schedules_data_source`
+- **New Data Source:** `netapp-ontap_ip_interface_data_source`
+- **New Data Source:** `netapp-ontap_ip_interfaces_data_source`
+- **New Data Source:** `netapp-ontap_name_services_dns_data_source`
+- **New Data Source:** `netapp-ontap_name_services_dnss_data_source`
+- **New Data Source:** `netapp-ontap_networking_ip_route_data_source`
+- **New Data Source:** `netapp-ontap_networking_ip_routes_data_source`
+- **New Data Source:** `netapp-ontap_protcols_nfs_service_data_source`
+- **New Data Source:** `netapp-ontap_protcols_nfs_services_data_source`
+- **New Data Source:** `netapp-ontap_protocols_nfs_export_policies_data_source`
+- **New Data Source:** `netapp-ontap_protocols_nfs_export_policy_data_source`
+- **New Data Source:** `netapp-ontap_protocols_nfs_export_policy_rule_data_source`
+- **New Data Source:** `netapp-ontap_snapmirror_policies_data_source`
+- **New Data Source:** `netapp-ontap_snapmirror_policy_data_source`
+- **New Data Source:** `netapp-ontap_storage_aggregate_data_source`
+- **New Data Source:** `netapp-ontap_storage_aggregates_data_source`
+- **New Data Source:** `netapp-ontap_storage_snapshot_policies_data_source`
+- **New Data Source:** `netapp-ontap_storage_snapshot_policy_data_source`
+- **New Data Source:** `netapp-ontap_storage_volume_data_source`
+- **New Data Source:** `netapp-ontap_storage_volumes_data_source`
+- **New Data Source:** `netapp-ontap_storage_volume_snapshot_data_source`
+- **New Data Source:** `netapp-ontap_svm_data_source`
+- **New Data Source:** `netapp-ontap_svms_data_source`
+- **New Resource:** `netapp-ontap_cluster_licensing_license_resource`
+- **New Resource:** `netapp-ontap_cluster_schedule_resource`
+- **New Resource:** `netapp-ontap_networking_ip_interface_resource`
+- **New Resource:** `netapp-ontap_name_services_dns_resource`
+- **New Resource:** `netapp-ontap_networking_ip_route_resource`
+- **New Resource:** `netapp-ontap_protocols_nfs_export_policy_resource`
+- **New Resource:** `netapp-ontap_protocols_nfs_export_policy_rule_resource`
+- **New Resource:** `netapp-ontap_snapmirror_resource`
+- **New Resource:** `netapp-ontap_snapmirror_policy_resource`
+- **New Resource:** `netapp-ontap_storage_aggregate_resource`
+- **New Resource:** `netapp-ontap_storage_snapshot_policy_resource`
+- **New Resource:** `netapp-ontap_storage_volume_resource`
+- **New Resource:** `netapp-ontap_storage_volume_snapshot_resource`
+- **New Resource:** `netapp-ontap_svm_resource`

--- a/docs/data-sources/svm.md
+++ b/docs/data-sources/svm.md
@@ -13,6 +13,7 @@ Retrieves the configuration of SVM
 ## Supported Platforms
 
 * On-prem ONTAP system 9.6 or higher
+  * `storage_limit` attribute supported with ONTAP system 9.13 or higher
 * Amazon FSx for NetApp ONTAP
 
 ## Example Usage

--- a/docs/data-sources/svm.md
+++ b/docs/data-sources/svm.md
@@ -44,3 +44,4 @@ data "netapp-ontap_svm" "svm" {
 - `max_volumes` (String) Maximum number of volumes that can be created on the svm. Expects an integer or unlimited
 - `snapshot_policy` (String) The name of the snapshot policy to manage
 - `subtype` (String) The subtype for svm to be created
+- `storage_limit` (Number) Maximum storage permitted on svm, in bytes

--- a/docs/data-sources/svms.md
+++ b/docs/data-sources/svms.md
@@ -13,6 +13,7 @@ Retrieves the configuration of SVMs.
 ## Supported Platforms
 
 * On-prem ONTAP system 9.6 or higher
+  * `storage_limit` attribute supported with ONTAP system 9.13 or higher
 * Amazon FSx for NetApp ONTAP
 
 ## Example Usage

--- a/docs/data-sources/svms.md
+++ b/docs/data-sources/svms.md
@@ -70,3 +70,4 @@ Read-Only:
 - `max_volumes` (String) Maximum number of volumes that can be created on the svm. Expects an integer or unlimited
 - `snapshot_policy` (String) The name of the snapshot policy to manage
 - `subtype` (String) The subtype for svm to be created
+- `storage_limit` (Number) Maximum storage permitted on svm, in bytes

--- a/docs/resources/svm.md
+++ b/docs/resources/svm.md
@@ -21,11 +21,12 @@ Create/Modify/Delete a SVM
 ## Supported Platforms
 
 * On-prem ONTAP system 9.6 or higher
+  * `storage_limit` attribute supported with ONTAP system 9.13 or higher
 * Amazon FSx for NetApp ONTAP
 
 ## Example Usage
 
-This creates a new SVM called `tfsvm4`. In IPspace `terraformIpspace_newname`, which can have up to 200 volumes which will be cased on aggr2
+This creates a new SVM called `tfsvm4` in IPspace `terraformIpspace_newname`, which can have up to 200 volumes and up to 1 GB storage, which will be cased on aggr2.
 
 ```terraform
 resource "netapp-ontap_svm" "example" {
@@ -35,8 +36,11 @@ resource "netapp-ontap_svm" "example" {
   comment = "test"
   snapshot_policy = "default-1weekly"
   language = "en_us.utf_8"
-  aggregates = ["aggr2"]
+  aggregates = [
+    { name = "aggr2" }
+  ]
   max_volumes = "200"
+  storage_limit = 1073741824
 }`
 ```
 

--- a/docs/resources/svm.md
+++ b/docs/resources/svm.md
@@ -61,6 +61,7 @@ resource "netapp-ontap_svm" "example" {
 - `max_volumes` (String) Maximum number of volumes that can be created on the svm. Expects an integer or unlimited
 - `snapshot_policy` (String) The name of the snapshot policy to manage
 - `subtype` (String) The subtype for svm to be created
+- `storage_limit` (Number) Maximum storage permitted on svm, in bytes
 
 ### Read-Only
 

--- a/examples/resources/netapp-ontap_svm/resource.tf
+++ b/examples/resources/netapp-ontap_svm/resource.tf
@@ -1,11 +1,14 @@
 resource "netapp-ontap_svm" "example" {
   cx_profile_name = "cluster2"
-  name = "tfsvm"
-  ipspace = "test"
-  comment = "test"
+  name            = "tfsvm"
+  ipspace         = "test"
+  comment         = "test"
   snapshot_policy = "default-1weekly"
   //subtype = "dp_destination"
   language = "en_us.utf_8"
-  aggregates = ["aggr1", "test"]
+  aggregates = [
+    { name = "aggr1" },
+    { name = "test" },
+  ]
   max_volumes = "200"
 }

--- a/examples/resources/netapp-ontap_svm/resource.tf
+++ b/examples/resources/netapp-ontap_svm/resource.tf
@@ -10,5 +10,6 @@ resource "netapp-ontap_svm" "example" {
     { name = "aggr1" },
     { name = "test" },
   ]
-  max_volumes = "200"
+  max_volumes   = "200"
+  storage_limit = 1073741824
 }

--- a/internal/interfaces/svm.go
+++ b/internal/interfaces/svm.go
@@ -45,6 +45,7 @@ type SvmGetDataSourceModel struct {
 	Language       string         `mapstructure:"language,omitempty"`
 	Aggregates     []Aggregate    `mapstructure:"aggregates,omitempty"`
 	MaxVolumes     string         `mapstructure:"max_volumes,omitempty"`
+	Storage        Storage        `mapstructure:"storage"`
 }
 
 // Ipspace describes the resource data model.
@@ -55,6 +56,11 @@ type Ipspace struct {
 // SnapshotPolicy describes the resource data model.
 type SnapshotPolicy struct {
 	Name string `mapstructure:"name,omitempty"`
+}
+
+// Storage describes the resource data model.
+type Storage struct {
+	Limit int `mapstructure:"limit,omitempty"`
 }
 
 // SvmDataSourceFilterModel describes the data source data model for queries.
@@ -125,7 +131,17 @@ func GetSvmByNameIgnoreNotFound(errorHandler *utils.ErrorHandler, r restclient.R
 func GetSvmByNameDataSource(errorHandler *utils.ErrorHandler, r restclient.RestClient, name string) (*SvmGetDataSourceModel, error) {
 	api := "svm/svms"
 	query := r.NewQuery()
-	query.Fields([]string{"name", "ipspace", "snapshot_policy", "subtype", "comment", "language", "max_volumes", "aggregates"})
+	query.Fields([]string{
+		"name",
+		"ipspace",
+		"snapshot_policy",
+		"subtype",
+		"comment",
+		"language",
+		"max_volumes",
+		"aggregates",
+		"storage.limit",
+	})
 	query.Add("name", name)
 	statusCode, response, err := r.GetNilOrOneRecord(api, query, nil)
 	if err == nil && response == nil {

--- a/internal/interfaces/svm.go
+++ b/internal/interfaces/svm.go
@@ -24,29 +24,29 @@ type SvmDataModelONTAP struct {
 
 // SvmResourceModel describes the resource data model.
 type SvmResourceModel struct {
-	Name           string              `mapstructure:"name,omitempty"`
-	Ipspace        Ipspace             `mapstructure:"ipspace"`
-	SnapshotPolicy SnapshotPolicy      `mapstructure:"snapshot_policy,omitempty"`
-	SubType        string              `mapstructure:"subtype,omitempty"`
+	Aggregates     []map[string]string `mapstructure:"aggregates"`
 	Comment        string              `mapstructure:"comment"`
+	Ipspace        Ipspace             `mapstructure:"ipspace"`
 	Language       string              `mapstructure:"language,omitempty"`
 	MaxVolumes     string              `mapstructure:"max_volumes,omitempty"`
-	Aggregates     []map[string]string `mapstructure:"aggregates"`
+	Name           string              `mapstructure:"name,omitempty"`
+	SnapshotPolicy SnapshotPolicy      `mapstructure:"snapshot_policy,omitempty"`
 	Storage        Storage             `mapstructure:"storage"`
+	SubType        string              `mapstructure:"subtype,omitempty"`
 }
 
 // SvmGetDataSourceModel describes the data source model.
 type SvmGetDataSourceModel struct {
-	Name           string         `mapstructure:"name"`
-	UUID           string         `mapstructure:"uuid"`
-	Ipspace        Ipspace        `mapstructure:"ipspace"`
-	SnapshotPolicy SnapshotPolicy `mapstructure:"snapshot_policy"`
-	SubType        string         `mapstructure:"subtype,omitempty"`
-	Comment        string         `mapstructure:"comment,omitempty"`
-	Language       string         `mapstructure:"language,omitempty"`
 	Aggregates     []Aggregate    `mapstructure:"aggregates,omitempty"`
+	Comment        string         `mapstructure:"comment,omitempty"`
+	Ipspace        Ipspace        `mapstructure:"ipspace"`
+	Language       string         `mapstructure:"language,omitempty"`
 	MaxVolumes     string         `mapstructure:"max_volumes,omitempty"`
+	Name           string         `mapstructure:"name"`
+	SnapshotPolicy SnapshotPolicy `mapstructure:"snapshot_policy"`
 	Storage        Storage        `mapstructure:"storage"`
+	SubType        string         `mapstructure:"subtype,omitempty"`
+	UUID           string         `mapstructure:"uuid"`
 }
 
 // Ipspace describes the resource data model.

--- a/internal/interfaces/svm.go
+++ b/internal/interfaces/svm.go
@@ -213,7 +213,7 @@ func GetSvmsByName(errorHandler *utils.ErrorHandler, r restclient.RestClient, fi
 }
 
 // CreateSvm to create svm
-func CreateSvm(errorHandler *utils.ErrorHandler, r restclient.RestClient, data SvmResourceModel, setAggrEmpty bool, setCommentEmpty bool, setStorageLimitEmpty bool) (*SvmGetDataModelONTAP, error) {
+func CreateSvm(errorHandler *utils.ErrorHandler, r restclient.RestClient, data SvmResourceModel, setAggrEmpty bool, setCommentEmpty bool) (*SvmGetDataModelONTAP, error) {
 	var body map[string]interface{}
 	if err := mapstructure.Decode(data, &body); err != nil {
 		return nil, errorHandler.MakeAndReportError("error encoding svm body", fmt.Sprintf("error on encoding svm/svms body: %s, body: %#v", err, data))
@@ -223,12 +223,6 @@ func CreateSvm(errorHandler *utils.ErrorHandler, r restclient.RestClient, data S
 	}
 	if setCommentEmpty {
 		delete(body, "comment")
-	}
-	if setStorageLimitEmpty {
-		// delete storage.limit from request body, so that ONTAP uses default value
-		if v, ok := body["storage"].(map[string]interface{}); ok {
-			delete(v, "limit")
-		}
 	}
 
 	query := r.NewQuery()

--- a/internal/interfaces/svm.go
+++ b/internal/interfaces/svm.go
@@ -129,10 +129,10 @@ func GetSvmByNameIgnoreNotFound(errorHandler *utils.ErrorHandler, r restclient.R
 }
 
 // GetSvmByNameDataSource to get data source svm info
-func GetSvmByNameDataSource(errorHandler *utils.ErrorHandler, r restclient.RestClient, name string) (*SvmGetDataSourceModel, error) {
+func GetSvmByNameDataSource(errorHandler *utils.ErrorHandler, r restclient.RestClient, name string, version versionModelONTAP) (*SvmGetDataSourceModel, error) {
 	api := "svm/svms"
 	query := r.NewQuery()
-	query.Fields([]string{
+	fields := []string{
 		"name",
 		"ipspace",
 		"snapshot_policy",
@@ -141,9 +141,13 @@ func GetSvmByNameDataSource(errorHandler *utils.ErrorHandler, r restclient.RestC
 		"language",
 		"max_volumes",
 		"aggregates",
-		"storage.limit",
-	})
+	}
+	if version.Generation >= 9 && version.Major >= 13 {
+		fields = append(fields, "storage.limit")
+	}
+	query.Fields(fields)
 	query.Add("name", name)
+
 	statusCode, response, err := r.GetNilOrOneRecord(api, query, nil)
 	if err == nil && response == nil {
 		err = fmt.Errorf("no response for GET %s", api)
@@ -161,10 +165,10 @@ func GetSvmByNameDataSource(errorHandler *utils.ErrorHandler, r restclient.RestC
 }
 
 // GetSvmsByName to get data source list svm info
-func GetSvmsByName(errorHandler *utils.ErrorHandler, r restclient.RestClient, filter *SvmDataSourceFilterModel) ([]SvmGetDataSourceModel, error) {
+func GetSvmsByName(errorHandler *utils.ErrorHandler, r restclient.RestClient, filter *SvmDataSourceFilterModel, version versionModelONTAP) ([]SvmGetDataSourceModel, error) {
 	api := "svm/svms"
 	query := r.NewQuery()
-	query.Fields([]string{
+	fields := []string{
 		"name",
 		"ipspace",
 		"snapshot_policy",
@@ -173,8 +177,11 @@ func GetSvmsByName(errorHandler *utils.ErrorHandler, r restclient.RestClient, fi
 		"language",
 		"max_volumes",
 		"aggregates",
-		"storage.limit",
-	})
+	}
+	if version.Generation >= 9 && version.Major >= 13 {
+		fields = append(fields, "storage.limit")
+	}
+	query.Fields(fields)
 
 	if filter != nil {
 		var filterMap map[string]interface{}

--- a/internal/interfaces/svm.go
+++ b/internal/interfaces/svm.go
@@ -31,7 +31,7 @@ type SvmResourceModel struct {
 	MaxVolumes     string              `mapstructure:"max_volumes,omitempty"`
 	Name           string              `mapstructure:"name,omitempty"`
 	SnapshotPolicy SnapshotPolicy      `mapstructure:"snapshot_policy,omitempty"`
-	Storage        Storage             `mapstructure:"storage"`
+	Storage        Storage             `mapstructure:"storage,omitempty"`
 	SubType        string              `mapstructure:"subtype,omitempty"`
 }
 
@@ -44,7 +44,7 @@ type SvmGetDataSourceModel struct {
 	MaxVolumes     string         `mapstructure:"max_volumes,omitempty"`
 	Name           string         `mapstructure:"name"`
 	SnapshotPolicy SnapshotPolicy `mapstructure:"snapshot_policy"`
-	Storage        Storage        `mapstructure:"storage"`
+	Storage        Storage        `mapstructure:"storage,omitempty"`
 	SubType        string         `mapstructure:"subtype,omitempty"`
 	UUID           string         `mapstructure:"uuid"`
 }
@@ -61,7 +61,7 @@ type SnapshotPolicy struct {
 
 // Storage describes the resource data model.
 type Storage struct {
-	Limit int `mapstructure:"limit"`
+	Limit int `mapstructure:"limit,omitempty"`
 }
 
 // SvmDataSourceFilterModel describes the data source data model for queries.

--- a/internal/interfaces/svm_test.go
+++ b/internal/interfaces/svm_test.go
@@ -104,7 +104,17 @@ func TestGetSvmByNameDataSource(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			got, err := GetSvmByNameDataSource(errorHandler, *r, "svmname")
+			got, err := GetSvmByNameDataSource(
+				errorHandler,
+				*r,
+				"svmname",
+				versionModelONTAP{
+					Full:       "NetApp Release 9.15.1P4: Sun Oct 27 20:15:53 UTC 2024",
+					Generation: 9,
+					Major:      15,
+					Minor:      1,
+				},
+			)
 			if err != nil {
 				fmt.Printf("err: %s\n", err)
 			}
@@ -181,7 +191,17 @@ func TestGetSvmsByName(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			got, err := GetSvmsByName(errorHandler, *r, &SvmDataSourceFilterModel{Name: ""})
+			got, err := GetSvmsByName(
+				errorHandler,
+				*r,
+				&SvmDataSourceFilterModel{Name: ""},
+				versionModelONTAP{
+					Full:       "NetApp Release 9.15.1P4: Sun Oct 27 20:15:53 UTC 2024",
+					Generation: 9,
+					Major:      15,
+					Minor:      1,
+				},
+			)
 			if err != nil {
 				fmt.Printf("err: %s\n", err)
 			}

--- a/internal/provider/svm/svm_data_source.go
+++ b/internal/provider/svm/svm_data_source.go
@@ -51,6 +51,7 @@ type SvmDataSourceModel struct {
 	Language       types.String   `tfsdk:"language"`
 	Aggregates     []types.String `tfsdk:"aggregates"`
 	MaxVolumes     types.String   `tfsdk:"max_volumes"`
+	StorageLimit   types.Int64    `tfsdk:"storage_limit"`
 	ID             types.String   `tfsdk:"id"`
 }
 
@@ -106,6 +107,10 @@ func (d *SvmDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			},
 			"max_volumes": schema.StringAttribute{
 				MarkdownDescription: "Maximum number of volumes that can be created on the svm. Expects an integer or unlimited",
+				Computed:            true,
+			},
+			"storage_limit": schema.Int64Attribute{
+				MarkdownDescription: "Maximum storage permitted on svm, in bytes",
 				Computed:            true,
 			},
 			"id": schema.StringAttribute{
@@ -170,6 +175,7 @@ func (d *SvmDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	data.Language = types.StringValue(restInfo.Language)
 	data.Aggregates = aggregates
 	data.MaxVolumes = types.StringValue(restInfo.MaxVolumes)
+	data.StorageLimit = types.Int64Value(int64(restInfo.Storage.Limit))
 
 	// Write logs using the tflog package
 	// Documentation: https://terraform.io/plugin/log

--- a/internal/provider/svm/svm_data_source.go
+++ b/internal/provider/svm/svm_data_source.go
@@ -155,7 +155,17 @@ func (d *SvmDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	restInfo, err := interfaces.GetSvmByNameDataSource(errorHandler, *client, data.Name.ValueString())
+	cluster, err := interfaces.GetCluster(errorHandler, *client)
+	if err != nil {
+		// error reporting done inside GetCluster
+		return
+	}
+	if cluster == nil {
+		errorHandler.MakeAndReportError("No cluster found", "cluster not found")
+		return
+	}
+
+	restInfo, err := interfaces.GetSvmByNameDataSource(errorHandler, *client, data.Name.ValueString(), cluster.Version)
 	if err != nil {
 		// error reporting done inside GetSvm
 		return

--- a/internal/provider/svm/svm_resource.go
+++ b/internal/provider/svm/svm_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -56,6 +57,7 @@ type SvmResourceModel struct {
 	Language       types.String `tfsdk:"language"`
 	Aggregates     []Aggregate  `tfsdk:"aggregates"`
 	MaxVolumes     types.String `tfsdk:"max_volumes"`
+	StorageLimit   types.Int64  `tfsdk:"storage_limit"`
 	ID             types.String `tfsdk:"id"`
 }
 
@@ -119,6 +121,12 @@ func (r *SvmResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"max_volumes": schema.StringAttribute{
 				MarkdownDescription: "Maximum number of volumes that can be created on the svm. Expects an integer or unlimited",
 				Optional:            true,
+			},
+			"storage_limit": schema.Int64Attribute{
+				MarkdownDescription: "Maximum storage permitted on svm, in bytes",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(0),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -191,6 +199,12 @@ func (r *SvmResource) Create(ctx context.Context, req resource.CreateRequest, re
 		request.MaxVolumes = data.MaxVolumes.ValueString()
 	}
 
+	setStorageLimitEmpty := true
+	if !data.StorageLimit.Equal(types.Int64Value(0)) {
+		setStorageLimitEmpty = false
+		request.Storage.Limit = int(data.StorageLimit.ValueInt64())
+	}
+
 	setAggrEmpty := false
 	if len(data.Aggregates) != 0 {
 		aggregates := []interfaces.Aggregate{}
@@ -214,7 +228,14 @@ func (r *SvmResource) Create(ctx context.Context, req resource.CreateRequest, re
 		// error reporting done inside NewClient
 		return
 	}
-	svm, err := interfaces.CreateSvm(errorHandler, *client, request, setAggrEmpty, setCommentEmpty)
+	svm, err := interfaces.CreateSvm(
+		errorHandler,
+		*client,
+		request,
+		setAggrEmpty,
+		setCommentEmpty,
+		setStorageLimitEmpty,
+	)
 	if err != nil {
 		return
 	}
@@ -295,6 +316,8 @@ func (r *SvmResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		data.MaxVolumes = types.StringValue(svm.MaxVolumes)
 	}
 
+	data.StorageLimit = types.Int64Value(int64(svm.Storage.Limit))
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -373,6 +396,10 @@ func (r *SvmResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			return
 		}
 		request.MaxVolumes = data.MaxVolumes.ValueString()
+	}
+
+	if !data.StorageLimit.Equal(state.StorageLimit) {
+		request.Storage.Limit = int(data.StorageLimit.ValueInt64())
 	}
 
 	// aggregates can be modified as empty list

--- a/internal/provider/svm/svm_resource.go
+++ b/internal/provider/svm/svm_resource.go
@@ -265,12 +265,23 @@ func (r *SvmResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		// error reporting done inside NewClient
 		return
 	}
+
+	cluster, err := interfaces.GetCluster(errorHandler, *client)
+	if err != nil {
+		// error reporting done inside GetCluster
+		return
+	}
+	if cluster == nil {
+		errorHandler.MakeAndReportError("No cluster found", "cluster not found")
+		return
+	}
+
 	tflog.Debug(ctx, fmt.Sprintf("read a svm resource: %#v", data))
 	var svm *interfaces.SvmGetDataSourceModel
 	if data.ID.ValueString() != "" {
 		svm, err = interfaces.GetSvm(errorHandler, *client, data.ID.ValueString())
 	} else {
-		svm, err = interfaces.GetSvmByNameDataSource(errorHandler, *client, data.Name.ValueString())
+		svm, err = interfaces.GetSvmByNameDataSource(errorHandler, *client, data.Name.ValueString(), cluster.Version)
 	}
 	if err != nil {
 		return

--- a/internal/provider/svm/svm_resource.go
+++ b/internal/provider/svm/svm_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -125,8 +124,6 @@ func (r *SvmResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"storage_limit": schema.Int64Attribute{
 				MarkdownDescription: "Maximum storage permitted on svm, in bytes",
 				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(0),
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
@@ -324,8 +321,6 @@ func (r *SvmResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		data.MaxVolumes = types.StringValue(svm.MaxVolumes)
 	}
 
-	data.StorageLimit = types.Int64Value(int64(svm.Storage.Limit))
-
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -406,7 +401,7 @@ func (r *SvmResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		request.MaxVolumes = data.MaxVolumes.ValueString()
 	}
 
-	if !data.StorageLimit.Equal(state.StorageLimit) {
+	if !data.StorageLimit.IsUnknown() {
 		request.Storage.Limit = int(data.StorageLimit.ValueInt64())
 	}
 

--- a/internal/provider/svm/svm_resource.go
+++ b/internal/provider/svm/svm_resource.go
@@ -199,9 +199,7 @@ func (r *SvmResource) Create(ctx context.Context, req resource.CreateRequest, re
 		request.MaxVolumes = data.MaxVolumes.ValueString()
 	}
 
-	setStorageLimitEmpty := true
-	if !data.StorageLimit.Equal(types.Int64Value(0)) {
-		setStorageLimitEmpty = false
+	if !data.StorageLimit.IsUnknown() {
 		request.Storage.Limit = int(data.StorageLimit.ValueInt64())
 	}
 
@@ -234,7 +232,6 @@ func (r *SvmResource) Create(ctx context.Context, req resource.CreateRequest, re
 		request,
 		setAggrEmpty,
 		setCommentEmpty,
-		setStorageLimitEmpty,
 	)
 	if err != nil {
 		return

--- a/internal/provider/svm/svm_resource_test.go
+++ b/internal/provider/svm/svm_resource_test.go
@@ -17,7 +17,7 @@ func TestAccSvmResource(t *testing.T) {
 		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSvmResourceConfig("tfsvm4", "test", "default"),
+				Config: testAccSvmResourceConfig("tfsvm4", "test", "default", 0),
 				Check: resource.ComposeTestCheckFunc(
 					// Check to see the svm name is correct,
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "name", "tfsvm4"),
@@ -25,25 +25,28 @@ func TestAccSvmResource(t *testing.T) {
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "ipspace", "Default"),
 					// Check that a ID has been set (we don't know what the vaule is as it changes
 					resource.TestCheckResourceAttrSet("netapp-ontap_svm.example", "id"),
-					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "comment", "test")),
+					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "comment", "test"),
+					// Check to see if storage_limit is set correctly
+					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "storage_limit", "0"),
+				),
 			},
 			// Update a comment
 			{
-				Config: testAccSvmResourceConfig("tfsvm4", "carchi8py was here", "default"),
+				Config: testAccSvmResourceConfig("tfsvm4", "carchi8py was here", "default", 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "comment", "carchi8py was here"),
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "name", "tfsvm4")),
 			},
 			// Update a comment with an empty string
 			{
-				Config: testAccSvmResourceConfig("tfsvm4", "", "default"),
+				Config: testAccSvmResourceConfig("tfsvm4", "", "default", 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "comment", ""),
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "name", "tfsvm4")),
 			},
 			// Update snapshot policy default-1weekly and comment "carchi8py was here"
 			{
-				Config: testAccSvmResourceConfig("tfsvm4", "carchi8py was here", "default-1weekly"),
+				Config: testAccSvmResourceConfig("tfsvm4", "carchi8py was here", "default-1weekly", 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "comment", "carchi8py was here"),
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "snapshot_policy", "default-1weekly"),
@@ -51,19 +54,19 @@ func TestAccSvmResource(t *testing.T) {
 			},
 			// Update snapshot policy with empty string
 			{
-				Config:      testAccSvmResourceConfig("tfsvm4", "carchi8py was here", ""),
+				Config:      testAccSvmResourceConfig("tfsvm4", "carchi8py was here", "", 0),
 				ExpectError: regexp.MustCompile("cannot be updated with empty string"),
 			},
 			// change SVM name
 			{
-				Config: testAccSvmResourceConfig("tfsvm3", "carchi8py was here", "default"),
+				Config: testAccSvmResourceConfig("tfsvm3", "carchi8py was here", "default", 0),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "comment", "carchi8py was here"),
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "name", "tfsvm3")),
 			},
 			// Fail if the name already exist
 			{
-				Config:      testAccSvmResourceConfig("terraform", "carchi8py was here", "default"),
+				Config:      testAccSvmResourceConfig("terraform", "carchi8py was here", "default", 0),
 				ExpectError: regexp.MustCompile("13434908"),
 			},
 			// Import and read
@@ -75,10 +78,22 @@ func TestAccSvmResource(t *testing.T) {
 					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "name", "terraform"),
 				),
 			},
+			// Update storage_limit
+			{
+				Config: testAccSvmResourceConfig("tfsvm3", "carchi8py was here", "default", (1024 * 1024 * 1024)), // 1GB
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_svm.example", "storage_limit", "1073741824"),
+				),
+			},
+			// Fail if storage_limit too low
+			{
+				Config:      testAccSvmResourceConfig("tfsvm3", "carchi8py was here", "default", (1024 * 1024)), // 1MB
+				ExpectError: regexp.MustCompile("13434880"),
+			},
 		},
 	})
 }
-func testAccSvmResourceConfig(svm, comment string, snapshotPolicy string) string {
+func testAccSvmResourceConfig(svm, comment, snapshotPolicy string, storageLimit int) string {
 	host := os.Getenv("TF_ACC_NETAPP_HOST5")
 	admin := os.Getenv("TF_ACC_NETAPP_USER")
 	password := os.Getenv("TF_ACC_NETAPP_PASS2")
@@ -113,5 +128,6 @@ resource "netapp-ontap_svm" "example" {
     },
   ]
   max_volumes = "unlimited"
-}`, host, admin, password, svm, comment, snapshotPolicy)
+	storage_limit = %d
+}`, host, admin, password, svm, comment, snapshotPolicy, storageLimit)
 }

--- a/internal/provider/svm/svms_data_source.go
+++ b/internal/provider/svm/svms_data_source.go
@@ -165,7 +165,18 @@ func (d *SvmsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			Name: data.Filter.Name.ValueString(),
 		}
 	}
-	restInfo, err := interfaces.GetSvmsByName(errorHandler, *client, filter)
+
+	cluster, err := interfaces.GetCluster(errorHandler, *client)
+	if err != nil {
+		// error reporting done inside GetCluster
+		return
+	}
+	if cluster == nil {
+		errorHandler.MakeAndReportError("No cluster found", "cluster not found")
+		return
+	}
+
+	restInfo, err := interfaces.GetSvmsByName(errorHandler, *client, filter, cluster.Version)
 	if err != nil {
 		// error reporting done inside GetSvms
 		return


### PR DESCRIPTION
Adds ability to configure `storage_limit` parameter of SVM.

Closes #302.

Acceptance tests pass:
```shell
$ TF_ACC=1 go test ./internal/provider/svm/svm_resource_test.go -v
=== RUN   TestAccSvmResource
--- PASS: TestAccSvmResource (33.36s)
PASS
ok      command-line-arguments  33.367s
```

Example Terraform Configuration:
```terraform
// sample SVM with storage_limit parameter
resource "netapp-ontap_svm" "example" {
  cx_profile_name = ...
  name            = ...
  ...
  storage_limit   = "4294967296"
}
```