### PR TITLE
[Enhancement]: Add interface `location.broadcast_domain` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 
 - **netapp-ontap_svm**: added `storage.limit` option. ([#302](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/302))
 - **netapp-ontap_network_ip_interface**: added `service_policy` option. ([#306](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/306))
+- **netapp-ontap_network_ip_interface**: added `location.broadcast_domain` option. ([#305](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/305))
 
 # 2.0.1 (2024-12-13)
 

--- a/docs/data-sources/networking_ip_interface.md
+++ b/docs/data-sources/networking_ip_interface.md
@@ -53,7 +53,6 @@ Read-Only:
 - `address` (String) IPInterface IP address
 - `netmask` (Number) IPInterface IP netmask
 
-
 <a id="nestedatt--location"></a>
 
 ### Nested Schema for `location`
@@ -62,3 +61,13 @@ Read-Only:
 
 - `home_node` (String) IPInterface home node
 - `home_port` (String) IPInterface home port
+- `broadcast_domain` (Attributes) (see [below for nested schema](#nestedatt--location--broadcast_domain))
+
+<a id="nestedatt--location--broadcast_domain"></a>
+
+### Nested Schema for `location.broadcast_domain`
+
+Read-Only:
+
+- `name` (String) Name of the broadcast domain, scoped to its IPspace
+- `id` (String) Broadcast domain UUID

--- a/docs/data-sources/networking_ip_interfaces.md
+++ b/docs/data-sources/networking_ip_interfaces.md
@@ -78,7 +78,6 @@ Read-Only:
 - `address` (String) IPInterface IP address
 - `netmask` (Number) IPInterface IP netmask
 
-
 <a id="nestedatt--ip_interfaces--location"></a>
 
 ### Nested Schema for `ip_interfaces.location`
@@ -87,3 +86,13 @@ Read-Only:
 
 - `home_node` (String) IPInterface home node
 - `home_port` (String) IPInterface home port
+- `broadcast_domain` (Attributes) (see [below for nested schema](#nestedatt--location--broadcast_domain))
+
+<a id="nestedatt--ip_interfaces--location--broadcast_domain"></a>
+
+### Nested Schema for `ip_interfaces.location.broadcast_domain`
+
+Read-Only:
+
+- `name` (String) Name of the broadcast domain, scoped to its IPspace
+- `id` (String) Broadcast domain UUID

--- a/docs/resources/network_ip_interface.md
+++ b/docs/resources/network_ip_interface.md
@@ -74,10 +74,20 @@ Required:
 
 ### Nested Schema for `location`
 
-Required:
+Optional:
 
 - `home_node` (String) IPInterface home node
 - `home_port` (String) IPInterface home port
+- `broadcast_domain` (Attributes) (see [below for nested schema](#nestedatt--location--broadcast_domain))
+
+<a id="nestedatt--location--broadcast_domain"></a>
+
+### Nested Schema for `location.broadcast_domain`
+
+Optional:
+
+- `name` (String) Name of the broadcast domain, scoped to its IPspace
+- `id` (String) Broadcast domain UUID
 
 ## Import
 

--- a/examples/data-sources/netapp-ontap_network_ip_interface/data-source.tf
+++ b/examples/data-sources/netapp-ontap_network_ip_interface/data-source.tf
@@ -1,12 +1,12 @@
 data "netapp-ontap_network_ip_interface" "cluster_scoped" {
   # required to know which system to interface with
-  cx_profile_name = "svacluster"
+  cx_profile_name = "cluster4"
   name            = "cluster_mgmt"
 }
 
 data "netapp-ontap_network_ip_interface" "svm_scoped" {
   # required to know which system to interface with
-  cx_profile_name = "svacluster"
+  cx_profile_name = "cluster4"
   name            = "ipv4-svm02-mgmt.labwi.sva.de"
   svm_name        = "svm02"
 }

--- a/examples/data-sources/netapp-ontap_network_ip_interface/data-source.tf
+++ b/examples/data-sources/netapp-ontap_network_ip_interface/data-source.tf
@@ -1,5 +1,12 @@
-data "netapp-ontap_network_ip_interface" "ip_interface" {
+data "netapp-ontap_network_ip_interface" "cluster_scoped" {
   # required to know which system to interface with
-  cx_profile_name = "cluster4"
-  name = "cluster_mgmt"
+  cx_profile_name = "svacluster"
+  name            = "cluster_mgmt"
+}
+
+data "netapp-ontap_network_ip_interface" "svm_scoped" {
+  # required to know which system to interface with
+  cx_profile_name = "svacluster"
+  name            = "ipv4-svm02-mgmt.labwi.sva.de"
+  svm_name        = "svm02"
 }

--- a/examples/data-sources/netapp-ontap_network_ip_interface/terraform.tfvars
+++ b/examples/data-sources/netapp-ontap_network_ip_interface/terraform.tfvars
@@ -1,0 +1,1 @@
+../../provider/terraform.tfvars

--- a/examples/data-sources/netapp-ontap_network_ip_interfaces/data-source.tf
+++ b/examples/data-sources/netapp-ontap_network_ip_interfaces/data-source.tf
@@ -1,9 +1,18 @@
-data "netapp-ontap_network_ip_interfaces" "ip_interfaces" {
+data "netapp-ontap_network_ip_interfaces" "cluster_scoped" {
   # required to know which system to interface with
-  cx_profile_name = "cluster4"
+  cx_profile_name = "svacluster"
   filter = {
-    name = "lif*"
-    svm_name = "*"
-    scope = "svm"
+    name  = "*"
+    scope = "cluster"
+  }
+}
+
+data "netapp-ontap_network_ip_interfaces" "svm_scoped" {
+  # required to know which system to interface with
+  cx_profile_name = "svacluster"
+  filter = {
+    name     = "*"
+    svm_name = "svm*"
+    scope    = "svm"
   }
 }

--- a/examples/data-sources/netapp-ontap_network_ip_interfaces/data-source.tf
+++ b/examples/data-sources/netapp-ontap_network_ip_interfaces/data-source.tf
@@ -1,6 +1,6 @@
 data "netapp-ontap_network_ip_interfaces" "cluster_scoped" {
   # required to know which system to interface with
-  cx_profile_name = "svacluster"
+  cx_profile_name = "cluster4"
   filter = {
     name  = "*"
     scope = "cluster"
@@ -9,7 +9,7 @@ data "netapp-ontap_network_ip_interfaces" "cluster_scoped" {
 
 data "netapp-ontap_network_ip_interfaces" "svm_scoped" {
   # required to know which system to interface with
-  cx_profile_name = "svacluster"
+  cx_profile_name = "cluster4"
   filter = {
     name     = "*"
     svm_name = "svm*"

--- a/examples/data-sources/netapp-ontap_network_ip_interfaces/terraform.tfvars
+++ b/examples/data-sources/netapp-ontap_network_ip_interfaces/terraform.tfvars
@@ -1,0 +1,1 @@
+../../provider/terraform.tfvars

--- a/examples/resources/netapp-ontap_network_ip_interface/resource.tf
+++ b/examples/resources/netapp-ontap_network_ip_interface/resource.tf
@@ -1,15 +1,35 @@
-resource "netapp-ontap_network_ip_interface" "ip_interface" {
+resource "netapp-ontap_network_ip_interface" "with_node_port" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
   name            = "testme"
   svm_name        = "ansibleSVM"
+
   ip = {
     address = "10.10.10.10"
     netmask = 20
   }
+
   location = {
-    home_port = "e0c"
-    home_node = "ontap_cluster_1-01"
+    home_port = "e0a-300"
+    home_node = "netapp_single-01"
+  }
+}
+
+resource "netapp-ontap_network_ip_interface" "with_broadcast_domain" {
+  # required to know which system to interface with
+  cx_profile_name = "cluster4"
+  name            = "testme"
+  svm_name        = "ansibleSVM"
+
+  ip = {
+    address = "10.10.10.20"
+    netmask = 20
+  }
+
+  location = {
+    broadcast_domain = {
+      name = "tf_test_mgmt_svm02"
+    }
   }
   service_policy = "default-management"
 }

--- a/examples/resources/netapp-ontap_network_ip_interface/resource.tf
+++ b/examples/resources/netapp-ontap_network_ip_interface/resource.tf
@@ -1,7 +1,7 @@
 resource "netapp-ontap_network_ip_interface" "with_node_port" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
-  name            = "testme"
+  name            = "testme1"
   svm_name        = "ansibleSVM"
 
   ip = {
@@ -10,15 +10,15 @@ resource "netapp-ontap_network_ip_interface" "with_node_port" {
   }
 
   location = {
-    home_port = "e0a-300"
-    home_node = "netapp_single-01"
+    home_port = "e0c"
+    home_node = "ontap_cluster_1-01"
   }
 }
 
 resource "netapp-ontap_network_ip_interface" "with_broadcast_domain" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
-  name            = "testme"
+  name            = "testme2"
   svm_name        = "ansibleSVM"
 
   ip = {

--- a/internal/interfaces/networking_ip_interface.go
+++ b/internal/interfaces/networking_ip_interface.go
@@ -55,13 +55,13 @@ type IPInterfaceResourceLocation struct {
 
 // IPInterfaceResourceHomeNode is the body data model for home_node field
 type IPInterfaceResourceHomeNode struct {
-	Name string `mapstructure:"name"`
+	Name string `mapstructure:"name,omitempty"`
 }
 
 // IPInterfaceResourceHomePort is the body data model for home_port field
 type IPInterfaceResourceHomePort struct {
-	Name string                      `mapstructure:"name"`
-	Node IPInterfaceResourceHomeNode `mapstructure:"node"`
+	Name string                      `mapstructure:"name,omitempty"`
+	Node IPInterfaceResourceHomeNode `mapstructure:"node,omitempty"`
 }
 
 // IPInterfaceBroadcastDomain is the body data model for broadcast_domain field

--- a/internal/interfaces/networking_ip_interface.go
+++ b/internal/interfaces/networking_ip_interface.go
@@ -48,8 +48,9 @@ type IPInterfaceResourceIP struct {
 
 // IPInterfaceResourceLocation is the body data model for location field
 type IPInterfaceResourceLocation struct {
-	HomeNode IPInterfaceResourceHomeNode `mapstructure:"home_node,omitempty"`
-	HomePort IPInterfaceResourceHomePort `mapstructure:"home_port,omitempty"`
+	HomeNode        IPInterfaceResourceHomeNode `mapstructure:"home_node,omitempty"`
+	HomePort        IPInterfaceResourceHomePort `mapstructure:"home_port,omitempty"`
+	BroadcastDomain IPInterfaceBroadcastDomain  `mapstructure:"broadcast_domain,omitempty"`
 }
 
 // IPInterfaceResourceHomeNode is the body data model for home_node field
@@ -61,6 +62,12 @@ type IPInterfaceResourceHomeNode struct {
 type IPInterfaceResourceHomePort struct {
 	Name string                      `mapstructure:"name"`
 	Node IPInterfaceResourceHomeNode `mapstructure:"node"`
+}
+
+// IPInterfaceBroadcastDomain is the body data model for broadcast_domain field
+type IPInterfaceBroadcastDomain struct {
+	Name string `mapstructure:"name,omitempty"`
+	UUID string `mapstructure:"uuid,omitempty"`
 }
 
 // IPInterfaceServicePolicy is the body data model for the service_policy field

--- a/internal/provider/networking/network_ip_interface_data_source.go
+++ b/internal/provider/networking/network_ip_interface_data_source.go
@@ -64,6 +64,7 @@ type LocationDataSourceModel struct {
 	BroadcastDomain *LocationBroadcastDomainDataSourceModel `tfsdk:"broadcast_domain"`
 }
 
+// LocationBroadcastDomainDataSourceModel describes the data source model for broadcast domain ID and name.
 type LocationBroadcastDomainDataSourceModel struct {
 	ID   types.String `tfsdk:"id"`
 	Name types.String `tfsdk:"name"`

--- a/internal/provider/networking/network_ip_interface_data_source.go
+++ b/internal/provider/networking/network_ip_interface_data_source.go
@@ -57,10 +57,16 @@ type IPDataSourceModel struct {
 	Netmask types.Int64  `tfsdk:"netmask"`
 }
 
-// LocationDataSourceModel describes the data source model for home node/port.
+// LocationDataSourceModel describes the data source model for home node/port and broadcast domain.
 type LocationDataSourceModel struct {
-	HomeNode types.String `tfsdk:"home_node"`
-	HomePort types.String `tfsdk:"home_port"`
+	HomeNode        types.String                            `tfsdk:"home_node"`
+	HomePort        types.String                            `tfsdk:"home_port"`
+	BroadcastDomain *LocationBroadcastDomainDataSourceModel `tfsdk:"broadcast_domain"`
+}
+
+type LocationBroadcastDomainDataSourceModel struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
 }
 
 // Metadata returns the data source type name.
@@ -113,6 +119,20 @@ func (d *IPInterfaceDataSource) Schema(ctx context.Context, req datasource.Schem
 					"home_port": schema.StringAttribute{
 						Computed:            true,
 						MarkdownDescription: "IPInterface home port",
+					},
+					"broadcast_domain": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"name": schema.StringAttribute{
+								MarkdownDescription: "Name of the broadcast domain, scoped to its IPspace",
+								Computed:            true,
+							},
+							"id": schema.StringAttribute{
+								MarkdownDescription: "Broadcast domain UUID",
+								Computed:            true,
+							},
+						},
+						MarkdownDescription: "Broadcast domain UUID along with a readable name",
+						Computed:            true,
 					},
 				},
 				Computed: true,
@@ -185,6 +205,10 @@ func (d *IPInterfaceDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.Location = &LocationDataSourceModel{
 		HomeNode: types.StringValue(restInfo.Location.HomeNode.Name),
 		HomePort: types.StringValue(restInfo.Location.HomePort.Name),
+		BroadcastDomain: &LocationBroadcastDomainDataSourceModel{
+			ID:   types.StringValue(restInfo.Location.BroadcastDomain.UUID),
+			Name: types.StringValue(restInfo.Location.BroadcastDomain.Name),
+		},
 	}
 	data.ServicePolicy = types.StringValue(restInfo.ServicePolicy.Name)
 

--- a/internal/provider/networking/network_ip_interface_resource.go
+++ b/internal/provider/networking/network_ip_interface_resource.go
@@ -53,10 +53,24 @@ type IPInterfaceResourceIP struct {
 	Netmask types.Int64  `tfsdk:"netmask"`
 }
 
-// IPInterfaceResourceLocation describes the resource data model for home node/port.
+// IPInterfaceResourceLocation describes the resource data model for home node/port and broadcast domain.
 type IPInterfaceResourceLocation struct {
-	HomeNode types.String `tfsdk:"home_node"`
-	HomePort types.String `tfsdk:"home_port"`
+	HomeNode        types.String `tfsdk:"home_node"`
+	HomePort        types.String `tfsdk:"home_port"`
+	BroadcastDomain types.Object `tfsdk:"broadcast_domain"`
+}
+
+// IPInterfaceResourceLocationBroadcastDomain describes the resource data model for broadcast domain ID and name.
+type IPInterfaceResourceLocationBroadcastDomain struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+func (bd IPInterfaceResourceLocationBroadcastDomain) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":   types.StringType,
+		"name": types.StringType,
+	}
 }
 
 // IPInterfaceResourceModel describes the resource data model.
@@ -121,6 +135,28 @@ func (r *IPInterfaceResource) Schema(ctx context.Context, req resource.SchemaReq
 						Optional:            true,
 						Computed:            true,
 					},
+					"broadcast_domain": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"name": schema.StringAttribute{
+								MarkdownDescription: "Name of the broadcast domain, scoped to its IPspace",
+								Optional:            true,
+								Computed:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
+							},
+							"id": schema.StringAttribute{
+								MarkdownDescription: "Broadcast domain UUID",
+								Optional:            true,
+								Computed:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
+							},
+						},
+						MarkdownDescription: "Broadcast domain UUID along with a readable name",
+						Optional:            true,
+						Computed:            true,
 					},
 				},
 				Required: true,
@@ -199,10 +235,24 @@ func (r *IPInterfaceResource) Read(ctx context.Context, req resource.ReadRequest
 	data.Name = types.StringValue(restInfo.Name)
 	data.UUID = types.StringValue(restInfo.UUID)
 
-	var location IPInterfaceResourceLocation
-	location.HomeNode = types.StringValue(restInfo.Location.HomeNode.Name)
-	location.HomePort = types.StringValue(restInfo.Location.HomePort.Name)
-	data.Location = &location
+	// construct broadcast_domain object
+	bd := IPInterfaceResourceLocationBroadcastDomain{
+		ID:   types.StringValue(restInfo.Location.BroadcastDomain.UUID),
+		Name: types.StringValue(restInfo.Location.BroadcastDomain.Name),
+	}
+	bdobject, diags := types.ObjectValueFrom(ctx, bd.AttributeTypes(), bd)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// populate location attributes
+	if data.Location == nil {
+		data.Location = &IPInterfaceResourceLocation{}
+	}
+	data.Location.HomeNode = types.StringValue(restInfo.Location.HomeNode.Name)
+	data.Location.HomePort = types.StringValue(restInfo.Location.HomePort.Name)
+	data.Location.BroadcastDomain = bdobject
 
 	var ip IPInterfaceResourceIP
 	ip.Address = types.StringValue(restInfo.IP.Address)
@@ -261,6 +311,19 @@ func (r *IPInterfaceResource) Create(ctx context.Context, req resource.CreateReq
 		}
 	}
 
+	// location.broadcast_domain is optional
+	if !data.Location.BroadcastDomain.IsUnknown() {
+		var bd IPInterfaceResourceLocationBroadcastDomain
+		diags := data.Location.BroadcastDomain.As(ctx, &bd, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		body.Location.BroadcastDomain = interfaces.IPInterfaceBroadcastDomain{
+			UUID: bd.ID.ValueString(),
+			Name: bd.Name.ValueString(),
+		}
 	}
 	body.ServicePolicy.Name = data.ServicePolicy.ValueString()
 
@@ -284,12 +347,24 @@ func (r *IPInterfaceResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// construct broadcast_domain object
+	bd := IPInterfaceResourceLocationBroadcastDomain{
+		ID:   types.StringValue(restInfo.Location.BroadcastDomain.UUID),
+		Name: types.StringValue(restInfo.Location.BroadcastDomain.Name),
+	}
+	bdobject, diags := types.ObjectValueFrom(ctx, bd.AttributeTypes(), bd)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// populate location attributes
 	if data.Location == nil {
 		data.Location = &IPInterfaceResourceLocation{}
 	}
 	data.Location.HomeNode = types.StringValue(restInfo.Location.HomeNode.Name)
 	data.Location.HomePort = types.StringValue(restInfo.Location.HomePort.Name)
+	data.Location.BroadcastDomain = bdobject
 
 	tflog.Trace(ctx, fmt.Sprintf("created a resource, UUID=%s", data.UUID))
 
@@ -372,12 +447,24 @@ func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	// construct broadcast_domain object
+	bd := IPInterfaceResourceLocationBroadcastDomain{
+		ID:   types.StringValue(restInfo.Location.BroadcastDomain.UUID),
+		Name: types.StringValue(restInfo.Location.BroadcastDomain.Name),
+	}
+	bdobject, diags := types.ObjectValueFrom(ctx, bd.AttributeTypes(), bd)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// populate location attributes
 	if data.Location == nil {
 		data.Location = &IPInterfaceResourceLocation{}
 	}
 	data.Location.HomeNode = types.StringValue(restInfo.Location.HomeNode.Name)
 	data.Location.HomePort = types.StringValue(restInfo.Location.HomePort.Name)
+	data.Location.BroadcastDomain = bdobject
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/networking/network_ip_interface_resource.go
+++ b/internal/provider/networking/network_ip_interface_resource.go
@@ -178,6 +178,7 @@ func (r *IPInterfaceResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 		},
 	}
+}
 
 // Configure adds the provider configured client to the resource.
 func (r *IPInterfaceResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/networking/network_ip_interface_resource.go
+++ b/internal/provider/networking/network_ip_interface_resource.go
@@ -384,17 +384,10 @@ func (r *IPInterfaceResource) Create(ctx context.Context, req resource.CreateReq
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data, state *IPInterfaceResourceModel
+	var data *IPInterfaceResourceModel
 
 	// Read Terraform plan data into the model
 	diags := req.Plan.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Read state file data
-	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -411,8 +404,8 @@ func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateReq
 	body.IP.Address = data.IP.Address.ValueString()
 	body.IP.Netmask = data.IP.Netmask.ValueInt64()
 
-	// location.home_port can be updated in-place
-	if !data.Location.HomePort.Equal(state.Location.HomePort) {
+	// location.home_port is optional and can be updated in-place
+	if !data.Location.HomePort.IsUnknown() {
 		body.Location.HomePort = interfaces.IPInterfaceResourceHomePort{
 			Name: data.Location.HomePort.ValueString(),
 			// Node: interfaces.IPInterfaceResourceHomeNode{
@@ -421,8 +414,8 @@ func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 	}
 
-	// location.home_node can be updated in-place
-	if !data.Location.HomeNode.Equal(state.Location.HomeNode) {
+	// location.home_node is optional can be updated in-place
+	if !data.Location.HomeNode.IsUnknown() {
 		body.Location.HomeNode = interfaces.IPInterfaceResourceHomeNode{
 			Name: data.Location.HomeNode.ValueString(),
 		}

--- a/internal/provider/networking/network_ip_interface_resource.go
+++ b/internal/provider/networking/network_ip_interface_resource.go
@@ -6,12 +6,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/interfaces"
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
@@ -107,16 +109,18 @@ func (r *IPInterfaceResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 				Required: true,
 			},
-			// TODO: Make location fields optionals once other options are supported
 			"location": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"home_node": schema.StringAttribute{
 						MarkdownDescription: "IPInterface home node",
-						Required:            true,
+						Optional:            true,
+						Computed:            true,
 					},
 					"home_port": schema.StringAttribute{
 						MarkdownDescription: "IPInterface home port",
-						Required:            true,
+						Optional:            true,
+						Computed:            true,
+					},
 					},
 				},
 				Required: true,
@@ -138,7 +142,6 @@ func (r *IPInterfaceResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 		},
 	}
-}
 
 // Configure adds the provider configured client to the resource.
 func (r *IPInterfaceResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -240,14 +243,24 @@ func (r *IPInterfaceResource) Create(ctx context.Context, req resource.CreateReq
 	body.SVM.Name = data.SVMName.ValueString()
 	body.IP.Address = data.IP.Address.ValueString()
 	body.IP.Netmask = data.IP.Netmask.ValueInt64()
-	body.Location.HomePort = interfaces.IPInterfaceResourceHomePort{
-		Name: data.Location.HomePort.ValueString(),
-		Node: interfaces.IPInterfaceResourceHomeNode{
-			Name: data.Location.HomeNode.ValueString(),
-		},
+
+	// location.home_port is optional
+	if data.Location.HomePort.ValueString() != "" {
+		body.Location.HomePort = interfaces.IPInterfaceResourceHomePort{
+			Name: data.Location.HomePort.ValueString(),
+			// Node: interfaces.IPInterfaceResourceHomeNode{
+			// 	Name: data.Location.HomeNode.ValueString(),
+			// },
+		}
 	}
-	body.Location.HomeNode = interfaces.IPInterfaceResourceHomeNode{
-		Name: data.Location.HomeNode.ValueString(),
+
+	// location.home_node is optional
+	if data.Location.HomeNode.ValueString() != "" {
+		body.Location.HomeNode = interfaces.IPInterfaceResourceHomeNode{
+			Name: data.Location.HomeNode.ValueString(),
+		}
+	}
+
 	}
 	body.ServicePolicy.Name = data.ServicePolicy.ValueString()
 
@@ -257,12 +270,26 @@ func (r *IPInterfaceResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// Call ONTAP REST API to create IP interface
 	resource, err := interfaces.CreateIPInterface(errorHandler, *client, body)
 	if err != nil {
 		return
 	}
 
 	data.UUID = types.StringValue(resource.UUID)
+
+	// Call ONTAP REST API again to read IP interface details
+	restInfo, err := interfaces.GetIPInterface(errorHandler, *client, data.UUID.ValueString())
+	if err != nil {
+		return
+	}
+
+	// populate location attributes
+	if data.Location == nil {
+		data.Location = &IPInterfaceResourceLocation{}
+	}
+	data.Location.HomeNode = types.StringValue(restInfo.Location.HomeNode.Name)
+	data.Location.HomePort = types.StringValue(restInfo.Location.HomePort.Name)
 
 	tflog.Trace(ctx, fmt.Sprintf("created a resource, UUID=%s", data.UUID))
 
@@ -282,10 +309,21 @@ func (r *IPInterfaceResource) Create(ctx context.Context, req resource.CreateReq
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data *IPInterfaceResourceModel
+	var data, state *IPInterfaceResourceModel
 
 	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Read state file data
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	var body interfaces.IPInterfaceResourceBodyDataModelONTAP
 	errorHandler := utils.NewErrorHandler(ctx, &resp.Diagnostics)
@@ -297,14 +335,22 @@ func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateReq
 	body.Name = data.Name.ValueString()
 	body.IP.Address = data.IP.Address.ValueString()
 	body.IP.Netmask = data.IP.Netmask.ValueInt64()
-	body.Location.HomePort = interfaces.IPInterfaceResourceHomePort{
-		Name: data.Location.HomePort.ValueString(),
-		Node: interfaces.IPInterfaceResourceHomeNode{
-			Name: data.Location.HomeNode.ValueString(),
-		},
+
+	// location.home_port can be updated in-place
+	if !data.Location.HomePort.Equal(state.Location.HomePort) {
+		body.Location.HomePort = interfaces.IPInterfaceResourceHomePort{
+			Name: data.Location.HomePort.ValueString(),
+			// Node: interfaces.IPInterfaceResourceHomeNode{
+			// 	Name: data.Location.HomeNode.ValueString(),
+			// },
+		}
 	}
-	body.Location.HomeNode = interfaces.IPInterfaceResourceHomeNode{
-		Name: data.Location.HomeNode.ValueString(),
+
+	// location.home_node can be updated in-place
+	if !data.Location.HomeNode.Equal(state.Location.HomeNode) {
+		body.Location.HomeNode = interfaces.IPInterfaceResourceHomeNode{
+			Name: data.Location.HomeNode.ValueString(),
+		}
 	}
 	body.ServicePolicy.Name = data.ServicePolicy.ValueString()
 
@@ -314,11 +360,24 @@ func (r *IPInterfaceResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	// Call ONTAP REST API to update IP interface
 	err = interfaces.UpdateIPInterface(errorHandler, *client, body, data.UUID.ValueString())
-
 	if err != nil {
 		return
 	}
+
+	// Call ONTAP REST API again to read IP interface details
+	restInfo, err := interfaces.GetIPInterface(errorHandler, *client, data.UUID.ValueString())
+	if err != nil {
+		return
+	}
+
+	// populate location attributes
+	if data.Location == nil {
+		data.Location = &IPInterfaceResourceLocation{}
+	}
+	data.Location.HomeNode = types.StringValue(restInfo.Location.HomeNode.Name)
+	data.Location.HomePort = types.StringValue(restInfo.Location.HomePort.Name)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/networking/network_ip_interface_resource_alias_test.go
+++ b/internal/provider/networking/network_ip_interface_resource_alias_test.go
@@ -21,29 +21,29 @@ func TestAccNetworkIpInterfaceResourceAlias(t *testing.T) {
 		Steps: []resource.TestStep{
 			// non-existant SVM return code 2621462. Must happen before create/read
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("non-existant", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("non-existant", "10.10.10.10", "e0d", "ontap_cluster_1-01", "default-data-files"),
 				ExpectError: regexp.MustCompile("2621462"),
 			},
 			// non-existant home node
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "e0d", "non-existant_home_node"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "e0d", "non-existant_home_node", "default-data-files"),
 				ExpectError: regexp.MustCompile("53281680"),
 			},
 			// non-existant broadcast domain
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.10.10", "non-existant_broadcast_domain"),
+				Config:      testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.10.10", "non-existant_broadcast_domain", "default-data-files"),
 				ExpectError: regexp.MustCompile("Code:\"2\""),
 			},
 			// empty location, no Home Node / Home Port / Broadcast Domain
 			// Error 1967111: "Home node must be specified by at least one location.home_node, location.home_port, or location.broadcast_domain field."
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "", ""),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "", "", "default-data-files"),
 				ExpectError: regexp.MustCompile("Code:\"1967111\""),
 			},
 
 			// Create and Read (with Home Port & Node)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "e0d", "ontap_cluster_1-01", "default-data-files"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-1"),
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "svm_name", "svm2"),
@@ -51,7 +51,7 @@ func TestAccNetworkIpInterfaceResourceAlias(t *testing.T) {
 			},
 			// Update and Read (with Home Port & Node)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.20", "e0d", "ontap_cluster_1-01"),
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.20", "e0d", "ontap_cluster_1-01", "default-data-iscsi"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-1"),
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.10.20"),
@@ -72,7 +72,7 @@ func TestAccNetworkIpInterfaceResourceAlias(t *testing.T) {
 
 			// Create and Read (with Broadcast Domain)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.20.10", "tf_test_data_svm0"),
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.20.10", "tf_test_data_svm0", "default-data-files"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-2"),
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "svm_name", "svm02"),
@@ -83,7 +83,7 @@ func TestAccNetworkIpInterfaceResourceAlias(t *testing.T) {
 			},
 			// Update and Read (with Broadcast Domain)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.20.20", "tf_test_data_svm0"),
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.20.20", "tf_test_data_svm0", "default-data-iscsi"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-2"),
 					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.20.20"),
@@ -132,26 +132,26 @@ provider "netapp-ontap" {
 	`, host, admin, password)
 }
 
-func testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias(svmName, address, homePort, homeNode string) string {
+func testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias(svmName, address, homePort, homeNode, servicePolicy string) string {
 	return testAccNetworkIPInterfaceProviderConfigAlias() + fmt.Sprintf(`
 resource "netapp-ontap_networking_ip_interface_resource" "example" {
 	cx_profile_name = "cluster4"
 	name = "test-interface-1"
 	svm_name = "%s"
-  	ip = {
-    	address = "%s"
-    	netmask = 18
-    }
-  	location = {
-    	home_port = "%s"
-    	home_node = "%s"
-  	}
+	ip = {
+		address = "%s"
+		netmask = 18
+	}
+	location = {
+		home_port = "%s"
+		home_node = "%s"
+	}
 	service_policy = "%s"
 }
-`, svmName, address, homePort, homeNode)
+`, svmName, address, homePort, homeNode, servicePolicy)
 }
 
-func testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias(svmName, address, broadcastDomain string) string {
+func testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias(svmName, address, broadcastDomain, servicePolicy string) string {
 	return testAccNetworkIPInterfaceProviderConfigAlias() + fmt.Sprintf(`
 resource "netapp-ontap_networking_ip_interface_resource" "example" {
 	cx_profile_name = "cluster4"
@@ -166,6 +166,7 @@ resource "netapp-ontap_networking_ip_interface_resource" "example" {
 			name = "%s"
 		}
 	}
+	service_policy = "%s"
 }
-`, svmName, address, broadcastDomain)
+`, svmName, address, broadcastDomain, servicePolicy)
 }

--- a/internal/provider/networking/network_ip_interface_resource_alias_test.go
+++ b/internal/provider/networking/network_ip_interface_resource_alias_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// example ID: aeef4e4f-a663-11ef-9ca8-00a0b8bc0407
+const idRegexAlias string = "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"
+
 func TestAccNetworkIpInterfaceResourceAlias(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
@@ -18,48 +21,96 @@ func TestAccNetworkIpInterfaceResourceAlias(t *testing.T) {
 		Steps: []resource.TestStep{
 			// non-existant SVM return code 2621462. Must happen before create/read
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigAlias("non-existant", "10.10.10.10", "ontap_cluster_1-01", "default-data-files"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("non-existant", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
 				ExpectError: regexp.MustCompile("2621462"),
 			},
 			// non-existant home node
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigAlias("terraform", "10.10.10.10", "non-existant_home_node", "default-data-files"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "e0d", "non-existant_home_node"),
 				ExpectError: regexp.MustCompile("53281680"),
 			},
-			// Create and Read
-			// {
-			// 	Config: testAccNetworkIPInterfaceResourceConfigAlias("terraform", "10.10.10.10", "ontap_cluster_1-01", "default-data-files"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "svm_name", "terraform"),
-			//    resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "service_policy", "default-data-files"),
-			// 	),
-			// },
-			// // Update and Read
-			// {
-			// 	Config: testAccNetworkIPInterfaceResourceConfigAlias("terraform", "10.10.10.20", "ontap_cluster_1-01", "default-data-iscsi"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.10.20"),
-			//    resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "service_policy", "default-data-iscsi"),
-			// 	),
-			// },
-			// Test importing a resource
-			// {
-			// 	ResourceName:  "netapp-ontap_networking_ip_interface_resource.example",
-			// 	ImportState:   true,
-			// 	ImportStateId: fmt.Sprintf("%s,%s,%s", "acc_test", "terraform", "cluster4"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "acc_test"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.193.180.56"),
-			// 	),
-			// },
+			// non-existant broadcast domain
+			{
+				Config:      testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.10.10", "non-existant_broadcast_domain"),
+				ExpectError: regexp.MustCompile("Code:\"2\""),
+			},
+			// empty location, no Home Node / Home Port / Broadcast Domain
+			// Error 1967111: "Home node must be specified by at least one location.home_node, location.home_port, or location.broadcast_domain field."
+			{
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "", ""),
+				ExpectError: regexp.MustCompile("Code:\"1967111\""),
+			},
+
+			// Create and Read (with Home Port & Node)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-1"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "svm_name", "svm2"),
+				),
+			},
+			// Update and Read (with Home Port & Node)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias("svm0", "10.10.10.20", "e0d", "ontap_cluster_1-01"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-1"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.10.20"),
+				),
+			},
+			// Test importing a resource (with Home Port & Node)
+			{
+				ResourceName:  "netapp-ontap_networking_ip_interface_resource.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s", "test-interface-1", "svm0", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-1"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.10.20"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_port", "e0d"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_node", "ontap_cluster_1-01"),
+				),
+			},
+
+			// Create and Read (with Broadcast Domain)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.20.10", "tf_test_data_svm0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-2"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "svm_name", "svm02"),
+					resource.TestMatchResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.broadcast_domain.id", regexp.MustCompile(idRegexAlias)),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_node", "ontap_cluster_1-01"),
+					resource.TestMatchResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_port", regexp.MustCompile("e0a-[0-9]+")),
+				),
+			},
+			// Update and Read (with Broadcast Domain)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias("svm0", "10.10.20.20", "tf_test_data_svm0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-2"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.20.20"),
+					resource.TestMatchResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.broadcast_domain.id", regexp.MustCompile(idRegexAlias)),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_node", "ontap_cluster_1-01"),
+					resource.TestMatchResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_port", regexp.MustCompile("e0a-[0-9]+")),
+				),
+			},
+			// Test importing a resource (with Broadcast Domain)
+			{
+				ResourceName:  "netapp-ontap_networking_ip_interface_resource.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s", "test-interface-2", "svm0", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "name", "test-interface-2"),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "ip.address", "10.10.20.20"),
+					resource.TestMatchResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.broadcast_domain.id", regexp.MustCompile(idRegexAlias)),
+					resource.TestCheckResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_node", "ontap_cluster_1-01"),
+					resource.TestMatchResourceAttr("netapp-ontap_networking_ip_interface_resource.example", "location.home_port", regexp.MustCompile("e0a-[0-9]+")),
+				),
+			},
 		},
 	})
 }
 
-func testAccNetworkIPInterfaceResourceConfigAlias(svmName, address, homeNode, servicePolicy string) string {
-	host := os.Getenv("TF_ACC_NETAPP_HOST5")
+func testAccNetworkIPInterfaceProviderConfigAlias() string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
 	admin := os.Getenv("TF_ACC_NETAPP_USER")
 	password := os.Getenv("TF_ACC_NETAPP_PASS2")
 	if host == "" || admin == "" || password == "" {
@@ -78,20 +129,43 @@ provider "netapp-ontap" {
     },
   ]
 }
+	`, host, admin, password)
+}
 
+func testAccNetworkIPInterfaceResourceConfigHomePortNodeAlias(svmName, address, homePort, homeNode string) string {
+	return testAccNetworkIPInterfaceProviderConfigAlias() + fmt.Sprintf(`
 resource "netapp-ontap_networking_ip_interface_resource" "example" {
 	cx_profile_name = "cluster4"
-	name = "test-interface"
+	name = "test-interface-1"
 	svm_name = "%s"
   	ip = {
     	address = "%s"
     	netmask = 18
     }
   	location = {
-    	home_port = "e0d"
+    	home_port = "%s"
     	home_node = "%s"
   	}
 	service_policy = "%s"
 }
-`, host, admin, password, svmName, address, homeNode, servicePolicy)
+`, svmName, address, homePort, homeNode)
+}
+
+func testAccNetworkIPInterfaceResourceConfigBroadcastDomainAlias(svmName, address, broadcastDomain string) string {
+	return testAccNetworkIPInterfaceProviderConfigAlias() + fmt.Sprintf(`
+resource "netapp-ontap_networking_ip_interface_resource" "example" {
+	cx_profile_name = "cluster4"
+	name = "test-interface-2"
+	svm_name = "%s"
+	ip = {
+		address = "%s"
+		netmask = 18
+	}
+	location = {
+		broadcast_domain = {
+			name = "%s"
+		}
+	}
+}
+`, svmName, address, broadcastDomain)
 }

--- a/internal/provider/networking/network_ip_interface_resource_test.go
+++ b/internal/provider/networking/network_ip_interface_resource_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// example ID: aeef4e4f-a663-11ef-9ca8-00a0b8bc0407
+const idRegex string = "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"
+
 func TestAccNetworkIpInterfaceResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
@@ -18,48 +21,96 @@ func TestAccNetworkIpInterfaceResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// non-existant SVM return code 2621462. Must happen before create/read
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfig("non-existant", "10.10.10.10", "ontap_cluster_1-01", "default-data-files"),
-				ExpectError: regexp.MustCompile("2621462"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("non-existant", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				ExpectError: regexp.MustCompile("Code:\"2621462\""),
 			},
 			// non-existant home node
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfig("terraform", "10.10.10.10", "non-existant_home_node", "default-data-files"),
-				ExpectError: regexp.MustCompile("53281680"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "e0d", "non-existant_home_node"),
+				ExpectError: regexp.MustCompile("Code:\"53281680\""),
 			},
-			// Create and Read
-			// {
-			// 	Config: testAccNetworkIPInterfaceResourceConfig("svm0", "10.10.10.10", "ontap_cluster_1-01", "default-data-files"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "svm_name", "svm0"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "service_policy", "default-data-files"),
-			// 	),
-			// },
-			// // Update and Read
-			// {
-			// 	Config: testAccNetworkIPInterfaceResourceConfig("svm0", "10.10.10.20", "ontap_cluster_1-01", "default-data-iscsi"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.10.20"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "service_policy", "default-data-iscsi"),
-			// 	),
-			// },
-			// // Test importing a resource
-			// {
-			// 	ResourceName:  "netapp-ontap_network_ip_interface.example",
-			// 	ImportState:   true,
-			// 	ImportStateId: fmt.Sprintf("%s,%s,%s", "test-interface", "svm0", "cluster4"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.10.20"),
-			// 	),
-			// },
+			// non-existant broadcast domain
+			{
+				Config:      testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.10.10", "non-existant_broadcast_domain"),
+				ExpectError: regexp.MustCompile("Code:\"2\""),
+			},
+			// empty location, no Home Node / Home Port / Broadcast Domain
+			// Error 1967111: "Home node must be specified by at least one location.home_node, location.home_port, or location.broadcast_domain field."
+			{
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "", ""),
+				ExpectError: regexp.MustCompile("Code:\"1967111\""),
+			},
+
+			// Create and Read (with Home Port & Node)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-1"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "svm_name", "svm0"),
+				),
+			},
+			// Update and Read (with Home Port & Node)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.20", "e0d", "ontap_cluster_1-01"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-1"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.10.20"),
+				),
+			},
+			// Test importing a resource (with Home Port & Node)
+			{
+				ResourceName:  "netapp-ontap_network_ip_interface.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s", "test-interface-1", "svm0", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-1"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.10.20"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_port", "e0d"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_node", "ontap_cluster_1-01"),
+				),
+			},
+
+			// Create and Read (with Broadcast Domain)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.20.10", "tf_test_data_svm0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-2"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "svm_name", "svm0"),
+					resource.TestMatchResourceAttr("netapp-ontap_network_ip_interface.example", "location.broadcast_domain.id", regexp.MustCompile(idRegex)),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_node", "ontap_cluster_1-01"),
+					resource.TestMatchResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_port", regexp.MustCompile("e0a-[0-9]+")),
+				),
+			},
+			// Update and Read (with Broadcast Domain)
+			{
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.20.20", "tf_test_data_svm0"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-2"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.20.20"),
+					resource.TestMatchResourceAttr("netapp-ontap_network_ip_interface.example", "location.broadcast_domain.id", regexp.MustCompile(idRegex)),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_node", "ontap_cluster_1-01"),
+					resource.TestMatchResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_port", regexp.MustCompile("e0a-[0-9]+")),
+				),
+			},
+			// Test importing a resource (with Home Port & Node)
+			{
+				ResourceName:  "netapp-ontap_network_ip_interface.example",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s", "test-interface-2", "svm0", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-2"),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.20.20"),
+					resource.TestMatchResourceAttr("netapp-ontap_network_ip_interface.example", "location.broadcast_domain.id", regexp.MustCompile(idRegex)),
+					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_node", "ontap_cluster_1-01"),
+					resource.TestMatchResourceAttr("netapp-ontap_network_ip_interface.example", "location.home_port", regexp.MustCompile("e0a-[0-9]+")),
+				),
+			},
 		},
 	})
 }
 
-func testAccNetworkIPInterfaceResourceConfig(svmName, address, homeNode, servicePolicy string) string {
-	host := os.Getenv("TF_ACC_NETAPP_HOST5")
+func testAccNetworkIPInterfaceProviderConfig() string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
 	admin := os.Getenv("TF_ACC_NETAPP_USER")
 	password := os.Getenv("TF_ACC_NETAPP_PASS2")
 	if host == "" || admin == "" || password == "" {
@@ -78,20 +129,42 @@ provider "netapp-ontap" {
     },
   ]
 }
+	`, host, admin, password)
+}
 
+func testAccNetworkIPInterfaceResourceConfigHomePortNode(svmName, address, homePort, homeNode string) string {
+	return testAccNetworkIPInterfaceProviderConfig() + fmt.Sprintf(`
 resource "netapp-ontap_network_ip_interface" "example" {
 	cx_profile_name = "cluster4"
-	name = "test-interface"
+	name = "test-interface-1"
 	svm_name = "%s"
-  	ip = {
-    	address = "%s"
-    	netmask = 18
-    }
-  	location = {
-    	home_port = "e0d"
-    	home_node = "%s"
-  	}
-	service_policy = "%s"
+	ip = {
+		address = "%s"
+		netmask = 18
+	}
+	location = {
+		home_port = "%s"
+		home_node = "%s"
+	}
 }
-`, host, admin, password, svmName, address, homeNode, servicePolicy)
+`, svmName, address, homePort, homeNode)
+}
+
+func testAccNetworkIPInterfaceResourceConfigBroadcastDomain(svmName, address, broadcastDomain string) string {
+	return testAccNetworkIPInterfaceProviderConfig() + fmt.Sprintf(`
+resource "netapp-ontap_network_ip_interface" "example" {
+	cx_profile_name = "cluster4"
+	name = "test-interface-2"
+	svm_name = "%s"
+	ip = {
+		address = "%s"
+		netmask = 18
+	}
+	location = {
+		broadcast_domain = {
+			name = "%s"
+		}
+	}
+}
+`, svmName, address, broadcastDomain)
 }

--- a/internal/provider/networking/network_ip_interface_resource_test.go
+++ b/internal/provider/networking/network_ip_interface_resource_test.go
@@ -21,29 +21,29 @@ func TestAccNetworkIpInterfaceResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// non-existant SVM return code 2621462. Must happen before create/read
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("non-existant", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("non-existant", "10.10.10.10", "e0d", "ontap_cluster_1-01", "default-data-files"),
 				ExpectError: regexp.MustCompile("Code:\"2621462\""),
 			},
 			// non-existant home node
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "e0d", "non-existant_home_node"),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "e0d", "non-existant_home_node", "default-data-files"),
 				ExpectError: regexp.MustCompile("Code:\"53281680\""),
 			},
 			// non-existant broadcast domain
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.10.10", "non-existant_broadcast_domain"),
+				Config:      testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.10.10", "non-existant_broadcast_domain", "default-data-files"),
 				ExpectError: regexp.MustCompile("Code:\"2\""),
 			},
 			// empty location, no Home Node / Home Port / Broadcast Domain
 			// Error 1967111: "Home node must be specified by at least one location.home_node, location.home_port, or location.broadcast_domain field."
 			{
-				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "", ""),
+				Config:      testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "", "", "default-data-files"),
 				ExpectError: regexp.MustCompile("Code:\"1967111\""),
 			},
 
 			// Create and Read (with Home Port & Node)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "e0d", "ontap_cluster_1-01"),
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.10", "e0d", "ontap_cluster_1-01", "default-data-files"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-1"),
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "svm_name", "svm0"),
@@ -51,7 +51,7 @@ func TestAccNetworkIpInterfaceResource(t *testing.T) {
 			},
 			// Update and Read (with Home Port & Node)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.20", "e0d", "ontap_cluster_1-01"),
+				Config: testAccNetworkIPInterfaceResourceConfigHomePortNode("svm0", "10.10.10.20", "e0d", "ontap_cluster_1-01", "default-data-iscsi"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-1"),
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.10.20"),
@@ -72,7 +72,7 @@ func TestAccNetworkIpInterfaceResource(t *testing.T) {
 
 			// Create and Read (with Broadcast Domain)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.20.10", "tf_test_data_svm0"),
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.20.10", "tf_test_data_svm0", "default-data-files"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-2"),
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "svm_name", "svm0"),
@@ -83,7 +83,7 @@ func TestAccNetworkIpInterfaceResource(t *testing.T) {
 			},
 			// Update and Read (with Broadcast Domain)
 			{
-				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.20.20", "tf_test_data_svm0"),
+				Config: testAccNetworkIPInterfaceResourceConfigBroadcastDomain("svm0", "10.10.20.20", "tf_test_data_svm0", "default-data-iscsi"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "name", "test-interface-2"),
 					resource.TestCheckResourceAttr("netapp-ontap_network_ip_interface.example", "ip.address", "10.10.20.20"),
@@ -132,7 +132,7 @@ provider "netapp-ontap" {
 	`, host, admin, password)
 }
 
-func testAccNetworkIPInterfaceResourceConfigHomePortNode(svmName, address, homePort, homeNode string) string {
+func testAccNetworkIPInterfaceResourceConfigHomePortNode(svmName, address, homePort, homeNode, servicePolicy string) string {
 	return testAccNetworkIPInterfaceProviderConfig() + fmt.Sprintf(`
 resource "netapp-ontap_network_ip_interface" "example" {
 	cx_profile_name = "cluster4"
@@ -146,11 +146,12 @@ resource "netapp-ontap_network_ip_interface" "example" {
 		home_port = "%s"
 		home_node = "%s"
 	}
+	service_policy = "%s"
 }
-`, svmName, address, homePort, homeNode)
+`, svmName, address, homePort, homeNode, servicePolicy)
 }
 
-func testAccNetworkIPInterfaceResourceConfigBroadcastDomain(svmName, address, broadcastDomain string) string {
+func testAccNetworkIPInterfaceResourceConfigBroadcastDomain(svmName, address, broadcastDomain, servicePolicy string) string {
 	return testAccNetworkIPInterfaceProviderConfig() + fmt.Sprintf(`
 resource "netapp-ontap_network_ip_interface" "example" {
 	cx_profile_name = "cluster4"
@@ -165,6 +166,7 @@ resource "netapp-ontap_network_ip_interface" "example" {
 			name = "%s"
 		}
 	}
+	service_policy = "%s"
 }
-`, svmName, address, broadcastDomain)
+`, svmName, address, broadcastDomain, servicePolicy)
 }

--- a/internal/provider/networking/network_ip_interfaces_data_source.go
+++ b/internal/provider/networking/network_ip_interfaces_data_source.go
@@ -129,6 +129,20 @@ func (d *IPInterfacesDataSource) Schema(ctx context.Context, req datasource.Sche
 									Computed:            true,
 									MarkdownDescription: "IPInterface home port",
 								},
+								"broadcast_domain": schema.SingleNestedAttribute{
+									Attributes: map[string]schema.Attribute{
+										"name": schema.StringAttribute{
+											MarkdownDescription: "Name of the broadcast domain, scoped to its IPspace",
+											Computed:            true,
+										},
+										"id": schema.StringAttribute{
+											MarkdownDescription: "Broadcast domain UUID",
+											Computed:            true,
+										},
+									},
+									MarkdownDescription: "Broadcast domain UUID along with a readable name",
+									Computed:            true,
+								},
 							},
 							Computed: true,
 						},
@@ -216,6 +230,10 @@ func (d *IPInterfacesDataSource) Read(ctx context.Context, req datasource.ReadRe
 		data.IPInterfaces[index].Location = &LocationDataSourceModel{
 			HomeNode: types.StringValue(record.Location.HomeNode.Name),
 			HomePort: types.StringValue(record.Location.HomePort.Name),
+			BroadcastDomain: &LocationBroadcastDomainDataSourceModel{
+				ID:   types.StringValue(record.Location.BroadcastDomain.UUID),
+				Name: types.StringValue(record.Location.BroadcastDomain.Name),
+			},
 		}
 	}
 


### PR DESCRIPTION
Adds ability to configure `location.broadcast_domain` parameter of IP Interfaces.

Closes #305.

Acceptance tests pass:
```shell
$ TF_ACC=1 go test ./internal/provider/networking/network_ip_interface_resource_test.go -v
=== RUN   TestAccNetworkIpInterfaceResource
--- PASS: TestAccNetworkIpInterfaceResource (10.65s)
PASS
ok      command-line-arguments  10.664s
```
```shell
$ TF_ACC=1 go test ./internal/provider/networking/network_ip_interface_resource_alias_test.go -v
=== RUN   TestAccNetworkIpInterfaceResourceAlias
--- PASS: TestAccNetworkIpInterfaceResourceAlias (9.21s)
PASS
ok      command-line-arguments  9.225s
```

Example Terraform Configurations:
```terraform
resource "netapp-ontap_network_ip_interface" "with_node_port" {
  cx_profile_name = ...
  name            = ...
  svm_name        = ...

  ip = { ... }

  location = {
    home_port = "e0a-100"
    home_node = "node1"
  }
}
```

```terraform
resource "netapp-ontap_network_ip_interface" "with_broadcast_domain" {
  cx_profile_name = ...
  name            = ...
  svm_name        = ...

  ip = { ... }

  location = {
    broadcast_domain = {
      name = "bd1"
    }
  }
}
```