### PR TITLE
245 - enhancement - netapp-ontap_volume resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ENHANCEMENTS:
 
 - **netapp-ontap_aggregate_data_source**, **netapp-ontap_aggregates_data_source**: added `space.block_storage.available` option ([#256](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/256))
+- **netapp-ontap_volume_resource**: added `autosize.*` options. ([#245](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/245))
 
 # 2.1.2 (not released)
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -61,6 +61,14 @@ resource "netapp-ontap_volume" "example" {
     security_style = "mixed"
     junction_path = "/testacc"
   }
+  autosize = {
+    minimum = 20
+    maximum = 60
+    shrink_threshold = 10
+    grow_threshold = 90
+    mode = "off"
+    size_unit = "mb"
+  }
 }
 ```
 
@@ -78,6 +86,7 @@ resource "netapp-ontap_volume" "example" {
 ### Optional
 
 - `analytics` (Attributes) (see [below for nested schema](#nestedatt--analytics))
+- `autosize` (Attributes) (see [below for nested schema](#nestedatt--autosize))
 - `comment` (String) Sets a comment associated with the volume
 - `efficiency` (Attributes) (see [below for nested schema](#nestedatt--efficiency))
 - `encryption` (Boolean) Whether or not to enable Volume Encryption
@@ -133,6 +142,22 @@ Optional:
 Optional:
 
 - `state` (String) Set file system analytics state of the volume
+
+<a id="nestedatt--autosize"></a>
+
+### Nested Schema for `autosize`
+
+Optional:
+
+- `grow_threshold` (Number) Used space threshold size, in percentage, for the automatic growth of the volume.
+- `maximum` (Number) Maximum size in bytes up to which a volume grows automatically. This size cannot be less than the current volume size, or less than or equal to the minimum size of volume.
+- `minimum` (Number) Minimum size in bytes up to which the volume shrinks automatically. This size cannot be greater than or equal to the maximum size of volume.
+- `mode` (String) Autosize mode for the volume.
+							    grow - Volume automatically grows when the amount of used space is above the 'grow_threshold' value.
+							   	grow_shrink - Volume grows or shrinks in response to the amount of space used.
+									off - Autosizing of the volume is disabled.
+- `shrink_threshold` (Number) Used space threshold size, in percentage, for the automatic shrinkage of the volume.
+- `size_unit` (String) The unit used to interpret the minimum or maximum size parameters
 
 <a id="nestedatt--efficiency"></a>
 

--- a/examples/resources/netapp-ontap_volume/resource.tf
+++ b/examples/resources/netapp-ontap_volume/resource.tf
@@ -1,5 +1,5 @@
 # creating a volume
-resource "netapp-ontap_volume" "example" {
+resource "netapp-ontap_volume" "example1" {
   cx_profile_name = "cluster4"
   name = "terraformTest2"
   svm_name = "ansibleSVM"
@@ -15,7 +15,7 @@ resource "netapp-ontap_volume" "example" {
 }
 
 # creating a volume with autosize options
-resource "netapp-ontap_volume" "example" {
+resource "netapp-ontap_volume" "example2" {
   cx_profile_name = "cluster4"
   name = "terraformTest3"
   svm_name = "ansibleSVM"

--- a/examples/resources/netapp-ontap_volume/resource.tf
+++ b/examples/resources/netapp-ontap_volume/resource.tf
@@ -1,3 +1,4 @@
+# creating a volume
 resource "netapp-ontap_volume" "example" {
   cx_profile_name = "cluster4"
   name = "terraformTest2"
@@ -9,6 +10,30 @@ resource "netapp-ontap_volume" "example" {
   ]
   space = {
     size = 20
+    size_unit = "mb"
+  }
+}
+
+# creating a volume with autosize options
+resource "netapp-ontap_volume" "example" {
+  cx_profile_name = "cluster4"
+  name = "terraformTest3"
+  svm_name = "ansibleSVM"
+  aggregates = [
+    {
+      name = "aggr2"
+    },
+  ]
+  space = {
+    size = 50
+    size_unit = "mb"
+  }
+  autosize = {
+    minimum = 20
+    maximum = 60
+    shrink_threshold = 10
+    grow_threshold = 90
+    mode = "off"
     size_unit = "mb"
   }
 }

--- a/internal/interfaces/storage_volume.go
+++ b/internal/interfaces/storage_volume.go
@@ -19,7 +19,7 @@ type StorageVolumeGetDataModelONTAP struct {
 	State          string
 	Type           string
 	Comment        string
-	SpaceGuarantee Guarantee `mapstructure:"guarantee"`
+	SpaceGuarantee Guarantee      `mapstructure:"guarantee"`
 	NAS            NAS
 	QOS            QOS
 	Encryption     Encryption
@@ -30,6 +30,7 @@ type StorageVolumeGetDataModelONTAP struct {
 	Analytics      Analytics
 	Language       string
 	Aggregates     []Aggregate
+	Autosize       Autosize       `mapstructure:"autosize,omitempty"`
 	UUID           string
 }
 
@@ -52,6 +53,7 @@ type StorageVolumeResourceModel struct {
 	Analytics      Analytics                `mapstructure:"analytics,omitempty"`
 	Language       string                   `mapstructure:"language,omitempty"`
 	Aggregates     []map[string]interface{} `mapstructure:"aggregates,omitempty"`
+	Autosize       Autosize                 `mapstructure:"autosize,omitempty"`
 }
 
 // Aggregate describes the resource data model.
@@ -149,6 +151,15 @@ type svm struct {
 	Name string `mapstructure:"name,omitempty"`
 }
 
+// Autosize describes the resource data model.
+type Autosize struct {
+	Minimum         int    `mapstructure:"minimum,omitempty"`
+	Maximum         int    `mapstructure:"maximum,omitempty"`
+	ShrinkThreshold int    `mapstructure:"shrink_threshold,omitempty"`
+	GrowThreshold   int    `mapstructure:"grow_threshold,omitempty"`
+	Mode            string `mapstructure:"mode,omitempty"`
+}
+
 // POW2BYTEMAP coverts size based on size unit.
 var POW2BYTEMAP = map[string]int{
 	// Here, 1 kb = 1024
@@ -210,7 +221,7 @@ func GetStorageVolume(errorHandler *utils.ErrorHandler, r restclient.RestClient,
 	query := r.NewQuery()
 	query.Fields([]string{"name", "svm.name", "aggregates", "space.size", "state", "type", "nas.export_policy.name", "nas.path", "guarantee.type", "space.snapshot.reserve_percent",
 		"nas.security_style", "encryption.enabled", "efficiency.policy.name", "nas.unix_permissions", "nas.gid", "nas.uid", "snapshot_policy.name", "language", "qos.policy.name",
-		"tiering.policy", "comment", "efficiency.compression", "tiering.min_cooling_days", "space.logical_space.enforcement", "space.logical_space.reporting", "snaplock.type", "analytics.state"})
+		"tiering.policy", "comment", "efficiency.compression", "tiering.min_cooling_days", "space.logical_space.enforcement", "space.logical_space.reporting", "snaplock.type", "analytics.state", "autosize"})
 	statusCode, response, err := r.GetNilOrOneRecord("storage/volumes/"+uuid, query, nil)
 	if err != nil {
 		return nil, errorHandler.MakeAndReportError("error reading volume info", fmt.Sprintf("error on GET storage/volumes: %s", err))
@@ -235,7 +246,7 @@ func GetStorageVolumeByName(errorHandler *utils.ErrorHandler, r restclient.RestC
 	query.Add("return_records", "true")
 	query.Fields([]string{"name", "uuid", "svm.name", "aggregates", "space.size", "state", "type", "nas.export_policy.name", "nas.path", "guarantee.type", "space.snapshot.reserve_percent",
 		"nas.security_style", "encryption.enabled", "efficiency.policy.name", "nas.unix_permissions", "nas.gid", "nas.uid", "snapshot_policy.name", "language", "qos.policy.name",
-		"tiering.policy", "comment", "efficiency.compression", "tiering.min_cooling_days", "space.logical_space.enforcement", "space.logical_space.reporting", "snaplock.type", "analytics.state"})
+		"tiering.policy", "comment", "efficiency.compression", "tiering.min_cooling_days", "space.logical_space.enforcement", "space.logical_space.reporting", "snaplock.type", "analytics.state", "autosize"})
 	statusCode, response, err := r.GetNilOrOneRecord("storage/volumes", query, nil)
 	if err != nil {
 		return nil, errorHandler.MakeAndReportError("error reading volume info by name", fmt.Sprintf("error on GET storage/volumes: %s", err))

--- a/internal/provider/storage/storage_volume_resource.go
+++ b/internal/provider/storage/storage_volume_resource.go
@@ -15,8 +15,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/interfaces"
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/restclient"
@@ -73,6 +76,7 @@ type StorageVolumeResourceModel struct {
 	Efficiency     types.Object                      `tfsdk:"efficiency"`
 	SnapLock       types.Object                      `tfsdk:"snaplock"`
 	Analytics      types.Object                      `tfsdk:"analytics"`
+	Autosize       types.Object                      `tfsdk:"autosize"`
 }
 
 // StorageVolumeResourceAggregates describes the analytics model.
@@ -124,6 +128,16 @@ type StorageVolumeResourceSpace struct {
 type StorageVolumeResourceSpaceLogicalSpace struct {
 	Enforcement types.Bool `tfsdk:"enforcement"`
 	Reporting   types.Bool `tfsdk:"reporting"`
+}
+
+// StorageVolumeResourceAutosize describes the autosize model.
+type StorageVolumeResourceAutosize struct {
+	Minimum         types.Int64  `tfsdk:"minimum"`
+	Maximum         types.Int64  `tfsdk:"maximum"`
+	ShrinkThreshold types.Int64  `tfsdk:"shrink_threshold"`
+	GrowThreshold   types.Int64  `tfsdk:"grow_threshold"`
+	Mode            types.String `tfsdk:"mode"`
+	SizeUnit        types.String `tfsdk:"size_unit"`
 }
 
 // Metadata returns the resource type name.
@@ -328,6 +342,52 @@ func (r *StorageVolumeResource) Schema(ctx context.Context, req resource.SchemaR
 					},
 				},
 			},
+			"autosize": schema.SingleNestedAttribute{
+				Optional: true,
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"minimum": schema.Int64Attribute{
+						MarkdownDescription: "Minimum size in bytes up to which the volume shrinks automatically. This size cannot be greater than or equal to the maximum size of volume.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"maximum": schema.Int64Attribute{
+						MarkdownDescription: "Maximum size in bytes up to which a volume grows automatically. This size cannot be less than the current volume size, or less than or equal to the minimum size of volume.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"shrink_threshold": schema.Int64Attribute{
+						MarkdownDescription: "Used space threshold size, in percentage, for the automatic shrinkage of the volume.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"grow_threshold": schema.Int64Attribute{
+						MarkdownDescription: "Used space threshold size, in percentage, for the automatic growth of the volume.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"mode": schema.StringAttribute{
+						MarkdownDescription: `
+											 Autosize mode for the volume.
+											 grow - Volume automatically grows when the amount of used space is above the 'grow_threshold' value.
+							   				 grow_shrink - Volume grows or shrinks in response to the amount of space used.
+											 off - Autosizing of the volume is disabled.
+											 `,
+						Optional:            true,
+						Computed:            true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("off", "grow", "grow_shrink"),
+						},
+					},
+					"size_unit": schema.StringAttribute{
+						MarkdownDescription: "The unit used to interpret the minimum or maximum size parameters",
+						Optional:            true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("bytes", "b", "kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"),
+						},
+					},
+				},
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Volume identifier",
@@ -375,6 +435,20 @@ func (r *StorageVolumeResource) Configure(ctx context.Context, req resource.Conf
 		)
 	}
 	r.config.ProviderConfig = config
+}
+
+// ConfigValidators validates entire resource configurations
+func (d *StorageVolumeResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+    return []resource.ConfigValidator{
+        resourcevalidator.RequiredTogether(
+            path.MatchRoot("autosize").AtName("minimum"),
+            path.MatchRoot("autosize").AtName("size_unit"),
+        ),
+		resourcevalidator.RequiredTogether(
+            path.MatchRoot("autosize").AtName("maximum"),
+            path.MatchRoot("autosize").AtName("size_unit"),
+        ),
+    }
 }
 
 // Read refreshes the Terraform state with the latest data.
@@ -543,6 +617,35 @@ func (r *StorageVolumeResource) Read(ctx context.Context, req resource.ReadReque
 		aggregates = append(aggregates, aggregate)
 	}
 	data.Aggregates = aggregates
+
+	//Autosize
+	elementTypes = map[string]attr.Type{
+		"minimum":          types.Int64Type,
+		"maximum":          types.Int64Type,
+		"shrink_threshold": types.Int64Type,
+		"grow_threshold":   types.Int64Type,
+		"mode":             types.StringType,
+		"size_unit":        types.StringType,
+	}
+	// var sizeUnit is already defined as part of Space model
+	var minimum int64
+	var maximum int64
+	minimum, sizeUnit = interfaces.ByteFormat(int64(response.Autosize.Minimum))
+	maximum, _ = interfaces.ByteFormat(int64(response.Autosize.Maximum))
+
+	elements = map[string]attr.Value{
+		"minimum":          types.Int64Value(minimum),
+		"maximum":          types.Int64Value(maximum),
+		"shrink_threshold": types.Int64Value(int64(response.Autosize.ShrinkThreshold)),
+		"grow_threshold":   types.Int64Value(int64(response.Autosize.GrowThreshold)),
+		"mode":             types.StringValue(response.Autosize.Mode),
+		"size_unit":        types.StringValue(sizeUnit),
+	}
+	objectValue, diags = types.ObjectValue(elementTypes, elements)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+	}
+	data.Autosize = objectValue
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -717,6 +820,34 @@ func (r *StorageVolumeResource) Create(ctx context.Context, req resource.CreateR
 		request.Analytics.State = analytics.State.ValueString()
 	}
 
+	if !data.Autosize.IsUnknown() {
+		var autosize StorageVolumeResourceAutosize
+		diags := data.Autosize.As(ctx, &autosize, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		sizeUnit = autosize.SizeUnit.ValueString()
+
+		if !autosize.Minimum.IsUnknown() {
+			// request.Autosize.Minimum = int(autosize.Minimum.ValueInt64())
+			request.Autosize.Minimum = int(autosize.Minimum.ValueInt64()) * interfaces.POW2BYTEMAP[autosize.SizeUnit.ValueString()]
+		}
+		if !autosize.Maximum.IsUnknown() {
+			// request.Autosize.Maximum = int(autosize.Maximum.ValueInt64())
+			request.Autosize.Maximum = int(autosize.Maximum.ValueInt64()) * interfaces.POW2BYTEMAP[autosize.SizeUnit.ValueString()]
+		}
+		if !autosize.ShrinkThreshold.IsUnknown() {
+			request.Autosize.ShrinkThreshold = int(autosize.ShrinkThreshold.ValueInt64())
+		}
+		if !autosize.GrowThreshold.IsUnknown() {
+			request.Autosize.GrowThreshold = int(autosize.GrowThreshold.ValueInt64())
+		}
+		if !autosize.Mode.IsUnknown() {
+			request.Autosize.Mode = autosize.Mode.ValueString()
+		}
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -854,6 +985,30 @@ func (r *StorageVolumeResource) Create(ctx context.Context, req resource.CreateR
 		resp.Diagnostics.Append(diags...)
 	}
 	data.Analytics = objectValue
+
+	//Autosize
+	elementTypes = map[string]attr.Type{
+		"minimum":          types.Int64Type,
+		"maximum":          types.Int64Type,
+		"shrink_threshold": types.Int64Type,
+		"grow_threshold":   types.Int64Type,
+		"mode":             types.StringType,
+		"size_unit":        types.StringType,
+	}
+	elements = map[string]attr.Value{
+		"minimum":          types.Int64Value(int64(response.Autosize.Minimum / interfaces.POW2BYTEMAP[sizeUnit])),
+		"maximum":          types.Int64Value(int64(response.Autosize.Maximum / interfaces.POW2BYTEMAP[sizeUnit])),
+		"shrink_threshold": types.Int64Value(int64(response.Autosize.ShrinkThreshold)),
+		"grow_threshold":   types.Int64Value(int64(response.Autosize.GrowThreshold)),
+		"mode":             types.StringValue(response.Autosize.Mode),
+		"size_unit":        types.StringValue(sizeUnit),
+	}
+	objectValue, diags = types.ObjectValue(elementTypes, elements)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+	}
+	data.Autosize = objectValue
+
 	tflog.Trace(ctx, "created a resource")
 
 	// Save data into Terraform state
@@ -1043,6 +1198,34 @@ func (r *StorageVolumeResource) Update(ctx context.Context, req resource.UpdateR
 				return
 			}
 			request.Analytics.State = analytics.State.ValueString()
+		}
+	}
+
+	if !plan.Autosize.IsUnknown() {
+		errorHandler := utils.NewErrorHandler(ctx, &resp.Diagnostics)
+		tflog.Debug(errorHandler.Ctx, fmt.Sprintf("autosize minimum in tfstate: %+v", state.Autosize))
+		if !plan.Autosize.Equal(state.Autosize) {
+			var autosize StorageVolumeResourceAutosize
+			diags := plan.Autosize.As(ctx, &autosize, basetypes.ObjectAsOptions{})
+			if diags.HasError() {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+			if !autosize.Minimum.IsUnknown() {
+				request.Autosize.Minimum = int(autosize.Minimum.ValueInt64()) * interfaces.POW2BYTEMAP[autosize.SizeUnit.ValueString()]
+			}
+			if !autosize.Maximum.IsUnknown() {
+				request.Autosize.Maximum = int(autosize.Maximum.ValueInt64()) * interfaces.POW2BYTEMAP[autosize.SizeUnit.ValueString()]
+			}
+			if !autosize.ShrinkThreshold.IsUnknown() {
+				request.Autosize.ShrinkThreshold = int(autosize.ShrinkThreshold.ValueInt64())
+			}
+			if !autosize.GrowThreshold.IsUnknown() {
+				request.Autosize.GrowThreshold = int(autosize.GrowThreshold.ValueInt64())
+			}
+			if !autosize.Mode.IsUnknown() {
+				request.Autosize.Mode = autosize.Mode.ValueString()
+			}
 		}
 	}
 
@@ -1249,6 +1432,38 @@ func readVolume(ctx context.Context, client *restclient.RestClient, data *Storag
 		allDiags.Append(diags...)
 	}
 	data.Analytics = objectValue
+
+	//Autosize
+	elementTypes = map[string]attr.Type{
+		"minimum":          types.Int64Type,
+		"maximum":          types.Int64Type,
+		"shrink_threshold": types.Int64Type,
+		"grow_threshold":   types.Int64Type,
+		"mode":             types.StringType,
+		"size_unit":        types.StringType,
+	}
+	// var sizeUnit is already defined as part of Space model
+	var autosize StorageVolumeResourceAutosize
+	diags = data.Autosize.As(ctx, &autosize, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		allDiags.Append(diags...)
+		return allDiags
+	}
+	sizeUnit = autosize.SizeUnit.ValueString()
+
+	elements = map[string]attr.Value{
+		"minimum":          types.Int64Value(int64(response.Autosize.Minimum / interfaces.POW2BYTEMAP[sizeUnit])),
+		"maximum":          types.Int64Value(int64(response.Autosize.Maximum / interfaces.POW2BYTEMAP[sizeUnit])),
+		"shrink_threshold": types.Int64Value(int64(response.Autosize.ShrinkThreshold)),
+		"grow_threshold":   types.Int64Value(int64(response.Autosize.GrowThreshold)),
+		"mode":             types.StringValue(response.Autosize.Mode),
+		"size_unit":        types.StringValue(sizeUnit),
+	}
+	objectValue, diags = types.ObjectValue(elementTypes, elements)
+	if diags.HasError() {
+		allDiags.Append(diags...)
+	}
+	data.Autosize = objectValue
 
 	return allDiags
 }

--- a/internal/provider/storage/storage_volume_resource.go
+++ b/internal/provider/storage/storage_volume_resource.go
@@ -830,11 +830,9 @@ func (r *StorageVolumeResource) Create(ctx context.Context, req resource.CreateR
 		sizeUnit = autosize.SizeUnit.ValueString()
 
 		if !autosize.Minimum.IsUnknown() {
-			// request.Autosize.Minimum = int(autosize.Minimum.ValueInt64())
 			request.Autosize.Minimum = int(autosize.Minimum.ValueInt64()) * interfaces.POW2BYTEMAP[autosize.SizeUnit.ValueString()]
 		}
 		if !autosize.Maximum.IsUnknown() {
-			// request.Autosize.Maximum = int(autosize.Maximum.ValueInt64())
 			request.Autosize.Maximum = int(autosize.Maximum.ValueInt64()) * interfaces.POW2BYTEMAP[autosize.SizeUnit.ValueString()]
 		}
 		if !autosize.ShrinkThreshold.IsUnknown() {

--- a/internal/provider/storage/storage_volume_resource_alias_test.go
+++ b/internal/provider/storage/storage_volume_resource_alias_test.go
@@ -106,6 +106,14 @@ resource "netapp-ontap_storage_volume_resource" "example" {
     security_style = "mixed"
 	junction_path = "/testacc"
   }
+  autosize = {
+    minimum = 20
+    maximum = 60
+    shrink_threshold = 10
+    grow_threshold = 90
+    mode = "off"
+    size_unit = "mb"
+  }
 }`, host, admin, password, volName, svm)
 }
 
@@ -159,6 +167,14 @@ resource "netapp-ontap_storage_volume_resource" "example" {
     unix_permissions = "755"
     security_style = "mixed"
 	junction_path = "/testacc"
+  }
+  autosize = {
+    minimum = 25
+    maximum = 65
+    shrink_threshold = 15
+    grow_threshold = 95
+    mode = "grow"
+    size_unit = "mb"
   }
 }`, host, admin, password, volName, svm)
 }

--- a/internal/provider/storage/storage_volume_resource_test.go
+++ b/internal/provider/storage/storage_volume_resource_test.go
@@ -106,6 +106,14 @@ resource "netapp-ontap_volume" "example" {
     security_style = "mixed"
 	junction_path = "/testacc"
   }
+  autosize = {
+    minimum = 20
+    maximum = 60
+    shrink_threshold = 10
+    grow_threshold = 90
+    mode = "off"
+    size_unit = "mb"
+  }
 }`, host, admin, password, volName, svm)
 }
 
@@ -159,6 +167,14 @@ resource "netapp-ontap_volume" "example" {
     unix_permissions = "755"
     security_style = "mixed"
 	junction_path = "/testacc"
+  }
+  autosize = {
+    minimum = 25
+    maximum = 65
+    shrink_threshold = 15
+    grow_threshold = 95
+    mode = "grow"
+    size_unit = "mb"
   }
 }`, host, admin, password, volName, svm)
 }


### PR DESCRIPTION
[Issue #245](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/245)
- added new options `autosize.*` to volume resource

```
[root@scs000344887 storage]# TF_ACC=1 go test `go list ./... | grep -e provider` -v -run=TestAccStorageVolumeResource
=== RUN   TestAccStorageVolumeResourceAlias
--- PASS: TestAccStorageVolumeResourceAlias (9.57s)
=== RUN   TestAccStorageVolumeResource
--- PASS: TestAccStorageVolumeResource (9.14s)
PASS
ok      github.com/netapp/terraform-provider-netapp-ontap/internal/provider/storage     18.713s
[root@scs000344887 storage]#
```