### PR TITLE
fix: add node name to `ethernet_port` import identifier to fix import in multi-node clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ DOCUMENTATION:
 
 - Corrected `aws` to `aws_lambda` in provider config.
 
+BUG FIXES:
+
+- **netapp-ontap_port**: error when importing VLANs in multi-node clusters ([#479](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/479))
 
 # 2.2.0 (2025-05-01)
 

--- a/docs/data-sources/network_ethernet_port.md
+++ b/docs/data-sources/network_ethernet_port.md
@@ -22,6 +22,9 @@ data "netapp-ontap_port" "physical" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
   name            = "e0a"
+  node = {
+    name = "netapp_single-01"
+  }
 }
 ```
 
@@ -30,6 +33,9 @@ data "netapp-ontap_port" "lag" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
   name            = "a0a"
+  node = {
+    name = "netapp_single-01"
+  }
 }
 ```
 
@@ -38,6 +44,9 @@ data "netapp-ontap_port" "vlan" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
   name            = "e0a-100"
+  node = {
+    name = "netapp_single-01"
+  }
 }
 ```
 
@@ -49,6 +58,7 @@ data "netapp-ontap_port" "vlan" {
 
 - `cx_profile_name` (String) Connection profile name
 - `name` (String) Portname, such as e0a, e1b-100 (VLAN on Ethernet), a0c (LAG/ifgrp), a0d-200 (VLAN on LAG/ifgrp), e0a.pv1 (p-VLAN, in select environments only)
+- `node` (Attributes) (see [below for nested schema](#nestedatt--node))
 
 ### Read-Only
 
@@ -58,7 +68,6 @@ data "netapp-ontap_port" "vlan" {
 - `lag` (Attributes) (see [below for nested schema](#nestedatt--lag))
 - `mac_address` (String) Port MAC address
 - `mtu` (Number) MTU of the port in bytes
-- `node` (Attributes) (see [below for nested schema](#nestedatt--node))
 - `rdma_protocols` (Set of String) Supported RDMA offload protocols
 - `reachability` (String) Reachability status of the port
 - `speed` (Number) Link speed in Mbps
@@ -92,9 +101,12 @@ Read-Only:
 
 ### Nested Schema for `node`
 
-Read-Only:
+Required:
 
 - `name` (String) Name of the node on which the port is located
+
+Read-Only:
+
 - `id` (String) Node UUID
 
 <a id="nestedatt--vlan"></a>

--- a/docs/resources/network_ethernet_port.md
+++ b/docs/resources/network_ethernet_port.md
@@ -143,15 +143,15 @@ Required:
 ## Import
 
 This Resource supports import, which allows you to import existing ethernet port into the state of this resoruce.
-Import require a unique ID composed of the cx_profile_name and port name, separated by a comma.
-id = `cx_profile_name`,`name`
+Import require a unique ID composed of the port name, node name, and cx_profile_name, separated by a comma.
+id = `name`,`node`,`cx_profile_name`
 
 ### Terraform Import
 
 For example
 
 ```shell
- terraform import netapp-ontap_port.example cluster4,e0a-300
+ terraform import netapp-ontap_port.example e0a-300,netapp_single-01,cluster4
 ```
 
 !> The terraform import CLI command can only import resources into the state. Importing via the CLI does not generate configuration. If you want to generate the accompanying configuration for imported resources, use the import block instead.
@@ -165,7 +165,7 @@ First create the block
 ```terraform
 import {
   to = netapp-ontap_port.vlan_import
-  id = "cluster4,e0a-300"
+  id = "e0a-300,netapp_single-01,cluster4"
 }
 ```
 
@@ -180,7 +180,7 @@ This will generate a file called generated.tf, which will contain the configurat
 ```terraform
 # __generated__ by Terraform
 # Please review these resources and move them into your main configuration files.
-# __generated__ by Terraform from "cluster4,e0a-300"
+# __generated__ by Terraform from "e0a-300,netapp_single-01,cluster4"
 resource "netapp-ontap_port" "vlan_import" {
   cx_profile_name = "cluster4"
   type            = "vlan"

--- a/examples/data-sources/netapp-ontap_port/data-source.tf
+++ b/examples/data-sources/netapp-ontap_port/data-source.tf
@@ -2,16 +2,25 @@ data "netapp-ontap_port" "physical" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
   name            = "e0a"
+  node = {
+    name = "netapp_single-01"
+  }
 }
 
 data "netapp-ontap_port" "lag" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
   name            = "a0a"
+  node = {
+    name = "netapp_single-01"
+  }
 }
 
 data "netapp-ontap_port" "vlan" {
   # required to know which system to interface with
   cx_profile_name = "cluster4"
-  name            = "e0a-100"
+  name            = "e0a-101"
+  node = {
+    name = "netapp_single-01"
+  }
 }

--- a/internal/interfaces/network_ethernet_port.go
+++ b/internal/interfaces/network_ethernet_port.go
@@ -151,9 +151,10 @@ func GetEthernetPort(errorHandler *utils.ErrorHandler, r restclient.RestClient, 
 
 // Retrieve ethernet port details
 // https://docs.netapp.com/us-en/ontap-restapi/ontap/get-network-ethernet-ports.html
-func GetEthernetPortByName(errorHandler *utils.ErrorHandler, r restclient.RestClient, name string) (*EthernetPortGetDataModelONTAP, error) {
+func GetEthernetPortByName(errorHandler *utils.ErrorHandler, r restclient.RestClient, node, name string) (*EthernetPortGetDataModelONTAP, error) {
 	api := "/network/ethernet/ports/"
 	query := r.NewQuery()
+	query.Set("node.name", node)
 	query.Set("name", name)
 	query.Fields([]string{
 		"broadcast_domain",

--- a/internal/provider/networking/network_ethernet_port_data_source.go
+++ b/internal/provider/networking/network_ethernet_port_data_source.go
@@ -160,7 +160,7 @@ func (d *EthernetPortDataSource) Schema(ctx context.Context, req datasource.Sche
 				Attributes: map[string]schema.Attribute{
 					"name": schema.StringAttribute{
 						MarkdownDescription: "Name of the node on which the port is located",
-						Computed:            true,
+						Required:            true,
 					},
 					"id": schema.StringAttribute{
 						MarkdownDescription: "Node UUID",
@@ -168,7 +168,7 @@ func (d *EthernetPortDataSource) Schema(ctx context.Context, req datasource.Sche
 					},
 				},
 				MarkdownDescription: "Node properties",
-				Computed:            true,
+				Required:            true,
 			},
 			"rdma_protocols": schema.SetAttribute{
 				MarkdownDescription: "Supported RDMA offload protocols",
@@ -257,6 +257,7 @@ func (d *EthernetPortDataSource) Read(ctx context.Context, req datasource.ReadRe
 	restInfo, err := interfaces.GetEthernetPortByName(
 		errorHandler,
 		*client,
+		data.Node.Name.ValueString(),
 		data.Name.ValueString(),
 	)
 	if err != nil {

--- a/internal/provider/networking/network_ethernet_port_resource.go
+++ b/internal/provider/networking/network_ethernet_port_resource.go
@@ -281,6 +281,7 @@ func (r *EthernetPortResource) Read(ctx context.Context, req resource.ReadReques
 		restInfo, err = interfaces.GetEthernetPortByName(
 			errorHandler,
 			*client,
+			data.Node.Name.ValueString(),
 			data.Name.ValueString(),
 		)
 		if err != nil {

--- a/internal/provider/networking/network_ethernet_port_resource.go
+++ b/internal/provider/networking/network_ethernet_port_resource.go
@@ -641,16 +641,17 @@ func (r *EthernetPortResource) ImportState(ctx context.Context, req resource.Imp
 
 	// Extract ethernet_port info from import identifier
 	idParts := strings.Split(req.ID, ",")
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: cx_profile_name,name, got: %q.", req.ID),
+			fmt.Sprintf("Expected import identifier with format: name,node,cx_profile_name, got: %q.", req.ID),
 		)
 
 		return
 	}
 
 	// Save ethernet_port info to attributes
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cx_profile_name"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), idParts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), idParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("node").AtName("name"), idParts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cx_profile_name"), idParts[2])...)
 }

--- a/internal/provider/networking/network_ethernet_port_resource_test.go
+++ b/internal/provider/networking/network_ethernet_port_resource_test.go
@@ -125,7 +125,7 @@ func TestAccNetworkEthernetPortResource(t *testing.T) {
 			// {
 			// 	ResourceName:  "netapp-ontap_port.vlan",
 			// 	ImportState:   true,
-			// 	ImportStateId: fmt.Sprintf("%s,%s", "cluster4", "e0a-300"),
+			// 	ImportStateId: fmt.Sprintf("%s,%s", "e0a-300", "bsuhas-vsim1", "cluster4"),
 			// 	Check: resource.ComposeTestCheckFunc(
 			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
 			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.name", "Default"),

--- a/internal/provider/networking/network_ethernet_port_resource_test.go
+++ b/internal/provider/networking/network_ethernet_port_resource_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // example ID: aeef4e4f-a663-11ef-9ca8-00a0b8bc0407
-// const idRegexNetworkEthernetPort string = "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"
+const idRegexNetworkEthernetPort string = "[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"
 
 func TestAccNetworkEthernetPortResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -21,7 +21,7 @@ func TestAccNetworkEthernetPortResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Error 1967088: The specified broadcast domain name does not exist in the specified IPspace
 			{
-				Config:      testAccNetworkEthernetPortLAGResourceConfig("non-existent", "non-existent", true, "bsuhas-vsim1", "mac", "\"e0b\",\"e0c\"", "singlemode"),
+				Config:      testAccNetworkEthernetPortLAGResourceConfig("non-existent", "non-existent", true, "netapp_single-01", "mac", "\"e0b\",\"e0c\"", "singlemode"),
 				ExpectError: regexp.MustCompile("Code:\"1967088\""),
 			},
 			// Error 1967085: The specified node name is not valid
@@ -31,113 +31,113 @@ func TestAccNetworkEthernetPortResource(t *testing.T) {
 			},
 			// Error 1967095: Invalid LAG member port name and node name combination
 			{
-				Config:      testAccNetworkEthernetPortLAGResourceConfig("Default", "Default", true, "bsuhas-vsim1", "mac", "\"e0z\"", "singlemode"),
+				Config:      testAccNetworkEthernetPortLAGResourceConfig("Default", "Default", true, "netapp_single-01", "mac", "\"e0z\"", "singlemode"),
 				ExpectError: regexp.MustCompile("Code:\"1967095\""),
 			},
 			// Error 1966466: VLAN ID must be a number from 1 to 4094
-			// {
-			// 	Config:      testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", true, "bsuhas-vsim1", "e0a", 9999),
-			// 	ExpectError: regexp.MustCompile("Code:\"1966466\""),
-			// },
-			// // Error 1967091: Invalid VLAN base port name
-			// {
-			// 	Config:      testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", true, "bsuhas-vsim1", "e0z", 300),
-			// 	ExpectError: regexp.MustCompile("Code:\"1967091\""),
-			// },
+			{
+				Config:      testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", true, "netapp_single-01", "e0a", 9999),
+				ExpectError: regexp.MustCompile("Code:\"1966466\""),
+			},
+			// Error 1967091: Invalid VLAN base port name
+			{
+				Config:      testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", true, "netapp_single-01", "e0z", 300),
+				ExpectError: regexp.MustCompile("Code:\"1967091\""),
+			},
 
 			// Create and Read LAG
-			// {
-			// 	Config: testAccNetworkEthernetPortLAGResourceConfig("Default", "Default", true, "bsuhas-vsim1", "mac", "\"e0b\",\"e0c\"", "singlemode"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.#", "1"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "name", "a0a"),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "up"),
-			// 	),
-			// },
-			// // Update (disable) and Read LAG
-			// {
-			// 	Config: testAccNetworkEthernetPortLAGResourceConfig("tf_test", "tf_test_data_svm02", false, "bsuhas-vsim1", "mac", "\"e0b\"", "singlemode"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.#", "0"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "down"),
-			// 	),
-			// },
-			// // Update (enable) and Read LAG
-			// {
-			// 	Config: testAccNetworkEthernetPortLAGResourceConfig("tf_test", "tf_test_data_svm02", true, "bsuhas-vsim1", "mac", "\"e0b\"", "singlemode"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.#", "1"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.0", "e0b"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "up"),
-			// 	),
-			// },
-			// // Test importing LAG
-			// {
-			// 	ResourceName:  "netapp-ontap_port.lag",
-			// 	ImportState:   true,
-			// 	ImportStateId: fmt.Sprintf("%s,%s", "cluster4", "a0a"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "broadcast_domain.name", "tf_test"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "broadcast_domain.name", "tf_test_data_svm02"),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.0", "e0b"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.distribution_policy", "mac"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.mode", "singlemode"),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.lag", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "node.name", "bsuhas-vsim1"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "up"),
-			// 	),
-			// },
+			{
+				Config: testAccNetworkEthernetPortLAGResourceConfig("Default", "Default", true, "netapp_single-01", "mac", "\"e0b\",\"e0c\"", "singlemode"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.#", "1"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "name", "a0a"),
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "up"),
+				),
+			},
+			// Update (disable) and Read LAG
+			{
+				Config: testAccNetworkEthernetPortLAGResourceConfig("tf_test", "tf_test_data_svm02", false, "netapp_single-01", "mac", "\"e0b\"", "singlemode"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.#", "0"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "down"),
+				),
+			},
+			// Update (enable) and Read LAG
+			{
+				Config: testAccNetworkEthernetPortLAGResourceConfig("tf_test", "tf_test_data_svm02", true, "netapp_single-01", "mac", "\"e0b\"", "singlemode"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.#", "1"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.0", "e0b"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "up"),
+				),
+			},
+			// Test importing LAG
+			{
+				ResourceName:  "netapp-ontap_port.lag",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s", "a0a", "netapp_single-01", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "broadcast_domain.name", "tf_test"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "broadcast_domain.name", "tf_test_data_svm02"),
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.active_ports.0", "e0b"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.distribution_policy", "mac"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "lag.mode", "singlemode"),
+					resource.TestMatchResourceAttr("netapp-ontap_port.lag", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "node.name", "netapp_single-01"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.lag", "state", "up"),
+				),
+			},
 
-			// // Create and Read VLAN
-			// {
-			// 	Config: testAccNetworkEthernetPortVLANResourceConfig("tf_test", "tf_test_data_svm02", true, "bsuhas-vsim1", "e0a", 300),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "name", "e0a-300"),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "reachability", "not_repairable"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "up"),
-			// 	),
-			// },
-			// // Update (disable) and Read VLAN
-			// {
-			// 	Config: testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", false, "bsuhas-vsim1", "e0a", 300),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "down"),
-			// 	),
-			// },
-			// // Update (disable) and Read VLAN
-			// {
-			// 	Config: testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", true, "bsuhas-vsim1", "e0a", 300),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "up"),
-			// 	),
-			// },
-			// // Test importing VLAN
-			// {
-			// 	ResourceName:  "netapp-ontap_port.vlan",
-			// 	ImportState:   true,
-			// 	ImportStateId: fmt.Sprintf("%s,%s", "e0a-300", "bsuhas-vsim1", "cluster4"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.name", "Default"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.name", "Default"),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "node.name", "bsuhas-vsim1"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "up"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "vlan.base_port", "e0a"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "vlan.tag", "300"),
-			// 	),
-			// },
+			// Create and Read VLAN
+			{
+				Config: testAccNetworkEthernetPortVLANResourceConfig("tf_test", "tf_test_data_svm02", true, "netapp_single-01", "e0a", 300),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "name", "e0a-300"),
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "reachability", "not_repairable"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "up"),
+				),
+			},
+			// Update (disable) and Read VLAN
+			{
+				Config: testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", false, "netapp_single-01", "e0a", 300),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "down"),
+				),
+			},
+			// Update (disable) and Read VLAN
+			{
+				Config: testAccNetworkEthernetPortVLANResourceConfig("Default", "Default", true, "netapp_single-01", "e0a", 300),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "up"),
+				),
+			},
+			// Test importing VLAN
+			{
+				ResourceName:  "netapp-ontap_port.vlan",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s,%s,%s", "e0a-300", "netapp_single-01", "cluster4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.name", "Default"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "broadcast_domain.name", "Default"),
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestMatchResourceAttr("netapp-ontap_port.vlan", "node.id", regexp.MustCompile(idRegexNetworkEthernetPort)),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "node.name", "netapp_single-01"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "state", "up"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "vlan.base_port", "e0a"),
+					resource.TestCheckResourceAttr("netapp-ontap_port.vlan", "vlan.tag", "300"),
+				),
+			},
 		},
 	})
 }
@@ -191,27 +191,27 @@ resource "netapp-ontap_port" "lag" {
 }`, bd_ipspace, bd_name, enabled, node_name, distribution_policy, member_ports, mode)
 }
 
-// func testAccNetworkEthernetPortVLANResourceConfig(bd_ipspace, bd_name string, enabled bool, node_name, base_port string, tag int64) string {
-// 	return testAccNetworkEthernetPortProviderConfig() + fmt.Sprintf(`
-// resource "netapp-ontap_port" "vlan" {
-// 	cx_profile_name = "cluster4"
+func testAccNetworkEthernetPortVLANResourceConfig(bd_ipspace, bd_name string, enabled bool, node_name, base_port string, tag int64) string {
+	return testAccNetworkEthernetPortProviderConfig() + fmt.Sprintf(`
+resource "netapp-ontap_port" "vlan" {
+	cx_profile_name = "cluster4"
 
-//   broadcast_domain = {
-//     ipspace = "%s"
-//     name    = "%s"
-//   }
+  broadcast_domain = {
+    ipspace = "%s"
+    name    = "%s"
+  }
 
-// 	enabled = %t
+	enabled = %t
 
-//   node = {
-//     name = "%s"
-//   }
+  node = {
+    name = "%s"
+  }
 
-//   type = "vlan"
-//   vlan = {
-//     base_port = "%s"
-//     tag       = %d
-//   }
-// }
-// `, bd_ipspace, bd_name, enabled, node_name, base_port, tag)
-// }
+  type = "vlan"
+  vlan = {
+    base_port = "%s"
+    tag       = %d
+  }
+}
+`, bd_ipspace, bd_name, enabled, node_name, base_port, tag)
+}


### PR DESCRIPTION
Fixes #479.

When importing ethernet_port (e.g. VLAN) resources in multi-node clusters, the port name (e.g. `a0a-1234`) might exist on multiple nodes. Hence, the port name alone is not sufficient to uniquely identify a particular ethernet_port resource. Importing an ambiguous ethernet port leads to the following error:

```shell
$ terraform import ... a0a-1234,cluster1

╷
│ Error: Error Reading Ethernet Port Info
│
│ Error on GET /network/ethernet/ports/: received 2 or more records when only
│ one is expected - statusCode 200, err=<nil>,
│ response=restclient.RestResponse{NumRecords:2,
│ Records:[]map[string]interface {}{ ... }
```

This PR adds the node name to the import identifier, i.e.:

```shell
$ terraform import ... a0a-1234,nodea,cluster1
$ terraform import ... a0a-1234,nodeb,cluster1
```

I've re-enabled and updated acceptance tests, and they do pass in my local test setup:

```shell
$ TF_ACC=1 go test ./internal/provider/networking/network_ethernet_port_resource_test.go -v
=== RUN   TestAccNetworkEthernetPortResource
--- PASS: TestAccNetworkEthernetPortResource (27.64s)
PASS
ok      command-line-arguments  27.668s
```

Let me know if you want me to disable ACC tests again...