### PR TITLE
fix: allow unlocking existing `security_account` resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ DOCUMENTATION:
 
 - Corrected `aws` to `aws_lambda` in provider config.
 
+BUG FIXES:
+
+- **netapp-ontap_security_account**: unable to unlock existing `security_account` resource ([#499](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/499))
 
 # 2.2.0 (2025-05-01)
 

--- a/internal/interfaces/security_account.go
+++ b/internal/interfaces/security_account.go
@@ -17,7 +17,7 @@ type SecurityAccountResourceBodyDataModelONTAP struct {
 	Role         SecurityAccountRole      `mapstructure:"role,omitempty"`
 	Password     string                   `mapstructure:"password,omitempty"`
 	Comment      string                   `mapstructure:"comment,omitempty"`
-	Locked       bool                     `mapstructure:"locked,omitempty"`
+	Locked       *bool                    `mapstructure:"locked,omitempty"`
 }
 
 // SecurityAccountGetDataModelONTAP describes the GET record data model using go types for mapping.
@@ -38,7 +38,7 @@ type SecurityAccountResourceUpdateBodyDataModelONTAP struct {
 	Role     SecurityAccountRole `mapstructure:"role,omitempty"`
 	Password string              `mapstructure:"password,omitempty"`
 	Comment  string              `mapstructure:"comment,omitempty"`
-	Locked   bool                `mapstructure:"locked,omitempty"`
+	Locked   *bool               `mapstructure:"locked,omitempty"`
 }
 
 // SecurityAccountApplication describes the application data model using go types for mapping.

--- a/internal/provider/security/security_account_resource.go
+++ b/internal/provider/security/security_account_resource.go
@@ -9,8 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -166,8 +164,6 @@ func (r *SecurityAccountResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: "Account locked",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
-				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "SecurityAccount id",
@@ -346,7 +342,7 @@ func (r *SecurityAccountResource) Create(ctx context.Context, req resource.Creat
 		body.Comment = data.Comment.ValueString()
 	}
 	if !data.Locked.IsNull() {
-		body.Locked = data.Locked.ValueBool()
+		body.Locked = data.Locked.ValueBoolPointer()
 	}
 
 	client, err := connection.GetRestClient(errorHandler, r.config, data.CxProfileName)
@@ -410,6 +406,7 @@ func (r *SecurityAccountResource) Create(ctx context.Context, req resource.Creat
 
 	data.ID = types.StringValue(resource.Name)
 	data.OwnerID = types.StringValue(resource.Owner.UUID)
+	data.Locked = types.BoolValue(resource.Locked)
 
 	tflog.Trace(ctx, "created a resource")
 
@@ -472,7 +469,7 @@ func (r *SecurityAccountResource) Update(ctx context.Context, req resource.Updat
 
 	// locked update
 	if !plan.Locked.IsNull() {
-		request.Locked = plan.Locked.ValueBool()
+		request.Locked = plan.Locked.ValueBoolPointer()
 	}
 
 	// comment update

--- a/internal/provider/security/security_account_resource_test.go
+++ b/internal/provider/security/security_account_resource_test.go
@@ -20,15 +20,25 @@ func TestAccSecurityAccountResource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "name", "tf_acc_test"),
 					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "password", "password123"),
+					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "locked", "false"),
 				),
 			},
 			// Test updating a resource with comment and locked
 			{
-				Config: testAccSecurityAccountResourceConfig("tf_acc_test", "update", true),
+				Config: testAccSecurityAccountResourceConfig("tf_acc_test", "locked", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "name", "tf_acc_test"),
-					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "comment", "update"),
+					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "comment", "locked"),
 					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "locked", "true"),
+				),
+			},
+			// Test updating a resource with comment and unlocked
+			{
+				Config: testAccSecurityAccountResourceConfig("tf_acc_test", "unlocked", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "name", "tf_acc_test"),
+					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "comment", "unlocked"),
+					resource.TestCheckResourceAttr("netapp-ontap_security_account.security_account", "locked", "false"),
 				),
 			},
 			// Test updating a resource with application and secondAuthenticationMethod


### PR DESCRIPTION
Fixes #499.

When unlocking existing, locked security accounts, Terraform produces the following error:

```shell
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to
│ netapp-ontap_security_account.security_account, provider
│ "provider[\"registry.terraform.io/netapp/netapp-ontap\"]" produced an
│ unexpected new value: .locked: was cty.False, but now cty.True.
│ 
│ This is a bug in the provider, which should be reported in the
│ provider's own issue tracker.
╵
```

This PR changes the internal data type of the `locked` attribute to bool pointer, to allow for three distinct values:
- null / undefined (-> omit attribute in REST call)
- true (-> lock account)
- false (-> unlock account)

ACC tests pass:

```shell
$ TF_ACC=1 go test ./internal/provider/security/security_account_resource_test.go -v
=== RUN   TestAccSecurityAccountResource
--- PASS: TestAccSecurityAccountResource (7.98s)
PASS
ok      command-line-arguments  7.988s
```