### PR TITLE
Fix use of use_tiered_aggregate in netapp-ontap_flexcache

### DIFF
--- a/internal/interfaces/storage_flexcache.go
+++ b/internal/interfaces/storage_flexcache.go
@@ -82,7 +82,7 @@ func GetStorageFlexcacheByName(errorHandler *utils.ErrorHandler, r restclient.Re
 	query := r.NewQuery()
 	query.Add("name", name)
 	query.Add("svm.name", svmName)
-	query.Fields([]string{"size", "path", "origins", "guarantee.type", "constituents_per_aggregate", "dr_cache", "global_file_locking_enabled", "use_tiered_aggregate", "aggregates"})
+	query.Fields([]string{"size", "path", "origins", "guarantee.type", "constituents_per_aggregate", "dr_cache", "global_file_locking_enabled", "aggregates"})
 	statusCode, response, err := r.GetNilOrOneRecord("storage/flexcache/flexcaches", query, nil)
 	if err != nil {
 		return nil, errorHandler.MakeAndReportError("error reading flexcache info", fmt.Sprintf("error on GET storage/flexcache/flexcaches: %s", err))
@@ -99,7 +99,7 @@ func GetStorageFlexcacheByName(errorHandler *utils.ErrorHandler, r restclient.Re
 func GetStorageFlexcaches(errorHandler *utils.ErrorHandler, r restclient.RestClient, filter *StorageFlexcacheDataSourceFilterModel) ([]StorageFlexcacheGetDataModelONTAP, error) {
 	api := "storage/flexcache/flexcaches"
 	query := r.NewQuery()
-	query.Fields([]string{"size", "path", "origins", "guarantee.type", "constituents_per_aggregate", "dr_cache", "global_file_locking_enabled", "use_tiered_aggregate", "aggregates"})
+	query.Fields([]string{"size", "path", "origins", "guarantee.type", "constituents_per_aggregate", "dr_cache", "global_file_locking_enabled", "aggregates"})
 	if filter != nil {
 		var filterMap map[string]interface{}
 		if err := mapstructure.Decode(filter, &filterMap); err != nil {

--- a/internal/provider/storage/storage_flexcache_data_source.go
+++ b/internal/provider/storage/storage_flexcache_data_source.go
@@ -53,7 +53,6 @@ type StorageFlexcacheDataSourceModel struct {
 	DrCache                  types.Bool   `tfsdk:"dr_cache"`
 	Guarantee                types.Object `tfsdk:"guarantee"`
 	GlobalFileLockingEnabled types.Bool   `tfsdk:"global_file_locking_enabled"`
-	UseTieredAggregate       types.Bool   `tfsdk:"use_tiered_aggregate"`
 	Aggregates               types.Set    `tfsdk:"aggregates"`
 	ID                       types.String `tfsdk:"id"`
 }
@@ -168,10 +167,6 @@ func (r *StorageFlexcacheDataSource) Schema(ctx context.Context, req datasource.
 				MarkdownDescription: "The state of the global file locking",
 				Computed:            true,
 			},
-			"use_tiered_aggregate": schema.BoolAttribute{
-				MarkdownDescription: "The state of the use tiered aggregates",
-				Computed:            true,
-			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The UUID of the flexcache volume",
 				Computed:            true,
@@ -231,7 +226,6 @@ func (r *StorageFlexcacheDataSource) Read(ctx context.Context, req datasource.Re
 	data.ConstituentsPerAggregate = types.Int64Value(int64(flexcache.ConstituentsPerAggregate))
 	data.DrCache = types.BoolValue(flexcache.DrCache)
 	data.GlobalFileLockingEnabled = types.BoolValue(flexcache.GlobalFileLockingEnabled)
-	data.UseTieredAggregate = types.BoolValue(flexcache.UseTieredAggregate)
 
 	elementTypes := map[string]attr.Type{
 		"type": types.StringType,

--- a/internal/provider/storage/storage_flexcache_resource.go
+++ b/internal/provider/storage/storage_flexcache_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -249,9 +250,12 @@ func (r *StorageFlexcacheResource) Schema(ctx context.Context, req resource.Sche
 				Optional:            true,
 			},
 			"use_tiered_aggregate": schema.BoolAttribute{
-				MarkdownDescription: "The state of the use tiered aggregates",
+				MarkdownDescription: "Whether to use a tiered aggregate. Only configurable at creation.",
 				Computed:            true,
 				Optional:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the volume",
@@ -299,7 +303,6 @@ func (r *StorageFlexcacheResource) Read(ctx context.Context, req resource.ReadRe
 	data.ConstituentsPerAggregate = types.Int64Value(int64(flexcache.ConstituentsPerAggregate))
 	data.DrCache = types.BoolValue(flexcache.DrCache)
 	data.GlobalFileLockingEnabled = types.BoolValue(flexcache.GlobalFileLockingEnabled)
-	data.UseTieredAggregate = types.BoolValue(flexcache.UseTieredAggregate)
 	data.ID = types.StringValue(flexcache.UUID)
 	elementTypes := map[string]attr.Type{
 		"type": types.StringType,
@@ -574,7 +577,6 @@ func (r *StorageFlexcacheResource) Create(ctx context.Context, req resource.Crea
 	data.ConstituentsPerAggregate = types.Int64Value(int64(flexcache.ConstituentsPerAggregate))
 	data.DrCache = types.BoolValue(flexcache.DrCache)
 	data.GlobalFileLockingEnabled = types.BoolValue(flexcache.GlobalFileLockingEnabled)
-	data.UseTieredAggregate = types.BoolValue(flexcache.UseTieredAggregate)
 	data.ID = types.StringValue(flexcache.UUID)
 
 	elementTypes := map[string]attr.Type{

--- a/internal/provider/storage/storage_flexcache_resource.go
+++ b/internal/provider/storage/storage_flexcache_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -253,6 +254,7 @@ func (r *StorageFlexcacheResource) Schema(ctx context.Context, req resource.Sche
 				MarkdownDescription: "Whether to use a tiered aggregate. Only configurable at creation.",
 				Computed:            true,
 				Optional:            true,
+				Default:             booldefault.StaticBool(false),
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/storage/storage_flexcaches_data_source.go
+++ b/internal/provider/storage/storage_flexcaches_data_source.go
@@ -187,10 +187,6 @@ func (r *StorageFlexcachesDataSource) Schema(ctx context.Context, req datasource
 							MarkdownDescription: "The state of the global file locking",
 							Computed:            true,
 						},
-						"use_tiered_aggregate": schema.BoolAttribute{
-							MarkdownDescription: "The state of the use tiered aggregates",
-							Computed:            true,
-						},
 						"id": schema.StringAttribute{
 							MarkdownDescription: "The UUID of the flexcache volume",
 							Computed:            true,
@@ -264,7 +260,6 @@ func (r *StorageFlexcachesDataSource) Read(ctx context.Context, req datasource.R
 		data.StorageFlexcaches[index].ConstituentsPerAggregate = types.Int64Value(int64(record.ConstituentsPerAggregate))
 		data.StorageFlexcaches[index].DrCache = types.BoolValue(record.DrCache)
 		data.StorageFlexcaches[index].GlobalFileLockingEnabled = types.BoolValue(record.GlobalFileLockingEnabled)
-		data.StorageFlexcaches[index].UseTieredAggregate = types.BoolValue(record.UseTieredAggregate)
 		data.StorageFlexcaches[index].ID = types.StringValue(record.UUID)
 
 		//guarantee


### PR DESCRIPTION
`use_tiered_aggregate` can only be set on flexcache creation. It cannot be changed or read from the API.

Stop trying to read it from the API and update state which causes errors if it's set to true. The default of false does not hit these errors.

Closes #581 