### PR TITLE
Don't always try to set locked status of security accounts

### DIFF
--- a/internal/provider/security/security_account_resource.go
+++ b/internal/provider/security/security_account_resource.go
@@ -341,7 +341,7 @@ func (r *SecurityAccountResource) Create(ctx context.Context, req resource.Creat
 	if !data.Comment.IsNull() {
 		body.Comment = data.Comment.ValueString()
 	}
-	if !data.Locked.IsNull() {
+	if !data.Locked.IsNull() && !data.Locked.IsUnknown() {
 		body.Locked = data.Locked.ValueBoolPointer()
 	}
 
@@ -468,7 +468,7 @@ func (r *SecurityAccountResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// locked update
-	if !plan.Locked.IsNull() {
+	if !plan.Locked.Equal(state.Locked) && !plan.Locked.IsNull() && !plan.Locked.IsUnknown() {
 		request.Locked = plan.Locked.ValueBoolPointer()
 	}
 

--- a/internal/provider/security/security_account_resource.go
+++ b/internal/provider/security/security_account_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -164,6 +165,7 @@ func (r *SecurityAccountResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: "Account locked",
 				Optional:            true,
 				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"id": schema.StringAttribute{
 				MarkdownDescription: "SecurityAccount id",
@@ -341,7 +343,7 @@ func (r *SecurityAccountResource) Create(ctx context.Context, req resource.Creat
 	if !data.Comment.IsNull() {
 		body.Comment = data.Comment.ValueString()
 	}
-	if !data.Locked.IsNull() && !data.Locked.IsUnknown() {
+	if !data.Locked.IsNull() && data.Locked.ValueBool() {
 		body.Locked = data.Locked.ValueBoolPointer()
 	}
 
@@ -468,7 +470,7 @@ func (r *SecurityAccountResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// locked update
-	if !plan.Locked.Equal(state.Locked) && !plan.Locked.IsNull() && !plan.Locked.IsUnknown() {
+	if !plan.Locked.Equal(state.Locked) {
 		request.Locked = plan.Locked.ValueBoolPointer()
 	}
 


### PR DESCRIPTION
Closes #598 

This would still run into permissions issues if the account was locked or if you tried to manually define the locked status. But it allows a security account like the below to be created on an FSx Ontap
```
resource "netapp-ontap_security_account" "harvest" {
  cx_profile_name = var.fsx_cx_profile_name
  name            = "harvest"
  applications = [
    {
      application            = "ontapi"
      authentication_methods = ["password"]
    }
  ]
  password = var.harvest_password
  role = {
    name = "fsxadmin-readonly"
  }
}
```