### PR TITLE
Allow provider URL scheme to be configured

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ Optional:
 
 - `aws_lambda` (Attributes) AWS configuration for Lambda (see [below for nested schema](#nestedatt--connection_profiles--aws_lambda))
 - `validate_certs` (Boolean) Whether to enforce SSL certificate validation, defaults to true. Not applicable for AWS Lambda
+- `scheme` (String) URL Scheme to be used to build the ONTAP management interface URL, defaults to https.
 
 <a id="nestedatt--connection_profiles--aws_lambda"></a>
 

--- a/internal/provider/connection/config.go
+++ b/internal/provider/connection/config.go
@@ -16,6 +16,7 @@ import (
 type Profile struct {
 	// TODO: add certs in addition to basic authentication
 	// TODO: Add Timeout (currently hardcoded to 10 seconds)
+	Scheme                string
 	Hostname              string
 	Username              string
 	Password              string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,6 +39,7 @@ type ONTAPProvider struct {
 // ConnectionProfileModel associate a connection profile with a name
 // TODO: augment address with hostname, ...
 type ConnectionProfileModel struct {
+	Scheme                types.String `tfsdk:"scheme"`
 	Name                  types.String `tfsdk:"name"`
 	Hostname              types.String `tfsdk:"hostname"`
 	Username              types.String `tfsdk:"username"`
@@ -90,6 +91,10 @@ func (p *ONTAPProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 						"name": schema.StringAttribute{
 							MarkdownDescription: "Profile name",
 							Required:            true,
+						},
+						"scheme": schema.StringAttribute{
+							MarkdownDescription: "URL Scheme to be used to build the ONTAP management interface URL, defaults to https",
+							Optional:            true,
 						},
 						"hostname": schema.StringAttribute{
 							MarkdownDescription: "ONTAP management interface IP address or name. For AWS Lambda, the management endpoints for the FSxN system.",
@@ -206,6 +211,7 @@ func (p *ONTAPProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		}
 
 		connectionProfiles[connectionProfile.Name.ValueString()] = connection.Profile{
+			Scheme:                connectionProfile.Scheme.ValueString(),
 			Hostname:              connectionProfile.Hostname.ValueString(),
 			Username:              username,
 			Password:              password,

--- a/internal/restclient/httpclient/http_client.go
+++ b/internal/restclient/httpclient/http_client.go
@@ -24,6 +24,7 @@ type HTTPClient struct {
 
 // HTTPProfile defines the connection attributes to build the base URL and authentication header
 type HTTPProfile struct {
+	Scheme        string
 	APIRoot       string
 	Hostname      string
 	Username      string

--- a/internal/restclient/httpclient/request.go
+++ b/internal/restclient/httpclient/request.go
@@ -80,7 +80,7 @@ func (r *Request) BuildURL(c *HTTPClient, baseURL string, uuid string) (string, 
 		return "", err
 	}
 	u := &url.URL{
-		Scheme: "https",
+		Scheme: c.cxProfile.Scheme,
 		Host:   c.cxProfile.Hostname,
 		Path:   c.cxProfile.APIRoot,
 	}

--- a/internal/restclient/httpclient/request_test.go
+++ b/internal/restclient/httpclient/request_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestRequest_BuildURL(t *testing.T) {
 	cxProfile := HTTPProfile{
+		Scheme: "https",
 		Hostname: "host",
 		APIRoot:  "api",
 	}
@@ -62,6 +63,7 @@ func TestRequest_BuildURL(t *testing.T) {
 
 func TestRequest_BuildHTTPReq(t *testing.T) {
 	cxProfile := HTTPProfile{
+		Scheme: "https",
 		Hostname: "host",
 		APIRoot:  "api",
 	}

--- a/internal/restclient/rest_client.go
+++ b/internal/restclient/rest_client.go
@@ -19,6 +19,7 @@ import (
 type ConnectionProfile struct {
 	// TODO: add certs in addition to basic authentication
 	// TODO: Add Timeout (currently hardcoded to 10 seconds)
+	Scheme                string
 	Hostname              string
 	Username              string
 	Password              string
@@ -225,6 +226,11 @@ func NewClient(ctx context.Context, cxProfile ConnectionProfile, tag string, job
 	httpProfile.CertFilepath = cxProfile.CertFilepath
 	httpProfile.KeyFilepath = cxProfile.KeyFilepath
 	httpProfile.CACertFile = cxProfile.CACertFile
+
+	if httpProfile.Scheme == "" {
+	  httpProfile.Scheme = "https"
+	}
+	
 	maxConcurrentRequests := cxProfile.MaxConcurrentRequests
 	if maxConcurrentRequests == 0 {
 		maxConcurrentRequests = 6


### PR DESCRIPTION
If there's a way to access the ONTAP management API in a non-https way, it should be allowed to be configured. This adds a new a new option to do so on the connection profile to allow using "http" for example.