### PR TITLE
686 resolve snapshot policy import issues

### DIFF
--- a/internal/provider/storage/storage_snapshot_policy_resource.go
+++ b/internal/provider/storage/storage_snapshot_policy_resource.go
@@ -123,17 +123,29 @@ func (r *SnapshotPolicyResource) Schema(ctx context.Context, req resource.Schema
 						"retention_period": schema.StringAttribute{
 							MarkdownDescription: "The retention period of Snapshot copies for this schedule",
 							Optional:            true,
-							PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"snapmirror_label": schema.StringAttribute{
 							MarkdownDescription: "Label for SnapMirror operations",
 							Optional:            true,
-							PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"prefix": schema.StringAttribute{
 							MarkdownDescription: "The prefix to use while creating Snapshot copies at regular intervals",
 							Optional:            true,
-							PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+							Computed:            true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},
@@ -222,6 +234,42 @@ func (r *SnapshotPolicyResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 	data.Name = types.StringValue(restInfo.Name)
 	data.ID = types.StringValue(restInfo.UUID)
+	data.Enabled = types.BoolValue(restInfo.Enabled)
+
+	if restInfo.Comment != "" {
+		data.Comment = types.StringValue(restInfo.Comment)
+	}
+
+	// iterate over the copies from the rest info and add them to the resource
+	if len(restInfo.Copies) > 0 {
+		var copies []CopyResourceModel
+		for _, restInfoCopy := range restInfo.Copies {
+			c := CopyResourceModel{
+				Count: types.Int64Value(restInfoCopy.Count),
+				Schedule: ScheduleResourceModel{
+					Name: types.StringValue(restInfoCopy.Schedule.Name),
+				},
+				RetentionPeriod: types.String{},
+				SnapmirrorLabel: types.String{},
+				Prefix:          types.String{},
+			}
+
+			// set optional fields
+			if restInfoCopy.RetentionPeriod != "" {
+				c.RetentionPeriod = types.StringValue(restInfoCopy.RetentionPeriod)
+			}
+
+			if restInfoCopy.SnapmirrorLabel != "" {
+				c.SnapmirrorLabel = types.StringValue(restInfoCopy.SnapmirrorLabel)
+			}
+
+			if restInfoCopy.Prefix != "" {
+				c.Prefix = types.StringValue(restInfoCopy.Prefix)
+			}
+			copies = append(copies, c)
+		}
+		data.Copies = copies
+	}
 
 	// Write logs using the tflog package
 	// Documentation: https://terraform.io/plugin/log
@@ -290,6 +338,43 @@ func (r *SnapshotPolicyResource) Create(ctx context.Context, req resource.Create
 
 	data.ID = types.StringValue(resource.UUID)
 	tflog.Trace(ctx, "created a resource")
+
+	// Optional values in the copies attribute may be filled by NetApp. Collect them after creating the resource.
+	restInfo, err := interfaces.GetSnapshotPolicy(errorHandler, *client, data.ID.ValueString())
+	if err != nil {
+		return
+	}
+
+	if len(restInfo.Copies) > 0 {
+		var restInfoCopies []CopyResourceModel
+		for _, restInfoCopy := range restInfo.Copies {
+			c := CopyResourceModel{
+				Count: types.Int64Value(restInfoCopy.Count),
+				Schedule: ScheduleResourceModel{
+					Name: types.StringValue(restInfoCopy.Schedule.Name),
+				},
+				// Set to StringNull to prevent "Unknown" state errors for computed values
+				RetentionPeriod: types.StringNull(),
+				SnapmirrorLabel: types.StringNull(),
+				Prefix:          types.StringNull(),
+			}
+
+			if restInfoCopy.RetentionPeriod != "" {
+				c.RetentionPeriod = types.StringValue(restInfoCopy.RetentionPeriod)
+			}
+
+			if restInfoCopy.SnapmirrorLabel != "" {
+				c.SnapmirrorLabel = types.StringValue(restInfoCopy.SnapmirrorLabel)
+			}
+
+			if restInfoCopy.Prefix != "" {
+				c.Prefix = types.StringValue(restInfoCopy.Prefix)
+			}
+			restInfoCopies = append(restInfoCopies, c)
+		}
+
+		data.Copies = restInfoCopies
+	}
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/storage/storage_snapshot_policy_resource.go
+++ b/internal/provider/storage/storage_snapshot_policy_resource.go
@@ -455,14 +455,18 @@ func (r *SnapshotPolicyResource) Delete(ctx context.Context, req resource.Delete
 // ImportState imports a resource using ID from terraform import command by calling the Read method.
 func (r *SnapshotPolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idParts := strings.Split(req.ID, ",")
-	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+	if len(idParts) != 3 || idParts[0] == "" || idParts[2] == "" {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
 			fmt.Sprintf("Expected import identifier with format: name,svm_name,cx_profile_name. Got: %q", req.ID),
 		)
 		return
 	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("svm_name"), idParts[1])...)
+	// if a policy is scoped to a cluster, the svm_name should be null
+	if idParts[1] != "" {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("svm_name"), idParts[1])...)
+	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cx_profile_name"), idParts[2])...)
 }

--- a/internal/provider/storage/storage_snapshot_policy_test.go
+++ b/internal/provider/storage/storage_snapshot_policy_test.go
@@ -46,6 +46,22 @@ func TestAccStorageSnapshotPolicyResource(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s,%s,%s", "tf-sn-policy", "tf_acc_svm", "cluster4"),
 				ImportStateVerify: true,
 			},
+			// Create cluster scoped storage snapshot policy and read
+			{
+				Config: testAccStorageSnapshotPolicyClusterResourceConfig("tf-cluster-sn-policy", "create a cluster scoped test snapshot policy", true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netapp-ontap_snapshot_policy.cluster_example", "name", "tf-cluster-sn-policy"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapshot_policy.cluster_example", "comment", "create a cluster scoped test snapshot policy"),
+					resource.TestCheckResourceAttr("netapp-ontap_snapshot_policy.cluster_example", "enabled", "true"),
+				),
+			},
+			// Test importing a cluster scoped storage snapshot policy
+			{
+				ResourceName:      "netapp-ontap_snapshot_policy.cluster_example",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s,,%s", "tf-cluster-sn-policy", "cluster4"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/storage/storage_snapshot_policy_test.go
+++ b/internal/provider/storage/storage_snapshot_policy_test.go
@@ -41,12 +41,10 @@ func TestAccStorageSnapshotPolicyResource(t *testing.T) {
 			},
 			// Test importing a resource
 			{
-				ResourceName:  "netapp-ontap_snapshot_policy.example",
-				ImportState:   true,
-				ImportStateId: fmt.Sprintf("%s,%s,%s", "tf_acc_snapshot_policy", "tf_acc_svm", "cluster4"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("netapp-ontap_snapshot_policy.example", "name", "tf_acc_snapshot_policy"),
-				),
+				ResourceName:      "netapp-ontap_snapshot_policy.example",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s,%s,%s", "tf-sn-policy", "tf_acc_svm", "cluster4"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -89,4 +87,42 @@ resource "netapp-ontap_snapshot_policy" "example" {
   },
   ]
 }`, host, admin, password, name, svmname, comment, enabled)
+}
+
+func testAccStorageSnapshotPolicyClusterResourceConfig(name string, comment string, enabled bool) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapshot_policy" "cluster_example" {
+  # required to know which system to interface with
+  cx_profile_name = "cluster4"
+  name = "%s"
+  comment = "%s"
+  enabled = "%t"
+  copies = [
+  {
+	count = 3
+	schedule = {
+	  name = "daily"
+	}
+  },
+  ]
+}`, host, admin, password, name, comment, enabled)
 }


### PR DESCRIPTION
This PR should resolve issue #686 , where we could not import a cluster level storage snapshot policy and the provider didn't read all fields (from NetApp) while creating resources.

Here, I made the following changes:

* After creating a storage snapshot policy resource, it reads the resource from NetApp to fill in the values for optional fields.
* The provider allows an empty svm name while importing a storage snapshot policy resource, because cluster level storage snapshot policies don't have an SVM.
* I fixed the unit test for importing a storage snapshot policy and added new tests for creating/importing cluster level storage snapshot policies.

My employer (SUSE LLC) has recently signed the CCLA. Please let me know if you need anything else.