### PR TITLE
728 enhancement snapmirror resync and break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.8.0
+
+ENHANCEMENTS:
+
+- **netapp-ontap_snapmirror**: Added support for snapmirror break and resync. ([#728](https://github.com/NetApp/terraform-provider-netapp-ontap/issues/728))
+
 # 2.7.1 (2026-07-30)
 
 BUG FIXES:

--- a/docs/resources/snapmirror.md
+++ b/docs/resources/snapmirror.md
@@ -42,6 +42,11 @@ resource "netapp-ontap_snapmirror" "snapmirror" {
       name = "hourly"
     }
   }
+  initialize = true
+  state = "snapmirrored"
+  force = false   # only set to true when breaking the relationship (state = "broken_off")
+  quick_resync = false # only set to true for resync (state = "snapmirrored")
+  transferring_time_out = 300
 }
 ```
 
@@ -57,8 +62,16 @@ resource "netapp-ontap_snapmirror" "snapmirror" {
 ### Optional
 
 - `create_destination` (String) Snapmirror provision destination.
+- `force` (Boolean) When changing `state` to `broken_off`, set to true to force break/failover checks.
 - `initialize` (Boolean) Initializes the Snapmirror relationship. By default, it is set to 'true'.
 - `policy` (Attributes) (see [below for nested schema](#nestedatt--policy))
+- `quick_resync` (Boolean) Modify-only flag. Set true to reduce resync time by not preserving storage efficiency. Used when resyncing from `broken_off`.
+- `state` (String) Desired relationship state. Common values include `snapmirrored` and `broken_off`.
+- `transferring_time_out` (Number) Maximum wait time in seconds for state transitions. Default is 300.
+
+### Computed
+
+- `healthy` (Boolean) Health reported by ONTAP for the relationship.
 
 ### Read-Only
 
@@ -178,3 +191,9 @@ resource "netapp-ontap_snapmirror" "snapmirror_import" {
   state = "snapmirrored"
 }
 ```
+
+## State Update Behavior
+
+- `state` is updated by polling ONTAP until the requested transition completes or `transferring_time_out` expires.
+- `force` is only applied when transitioning to `broken_off`.
+- `quick_resync` is only applied for state-changing updates from `broken_off` when user sets it to true.

--- a/examples/resources/netapp-ontap_snapmirror/resource.tf
+++ b/examples/resources/netapp-ontap_snapmirror/resource.tf
@@ -7,4 +7,9 @@ resource "netapp-ontap_snapmirror" "snapmirror_async" {
   destination_endpoint = {
     path = "snapmirror_dest_svm:snap_dest"
   }
+  initialize = true
+  state = "snapmirrored"
+  force = false   # only set to true when breaking the relationship (state = "broken_off")
+  transferring_time_out = 600
+  quick_resync = false # Only set for resync snapmirror
 }

--- a/internal/interfaces/snapmirror.go
+++ b/internal/interfaces/snapmirror.go
@@ -14,6 +14,8 @@ type SnapmirrorGetDataModelONTAP struct {
 	Healthy bool             `mapstructure:"healthy"`
 	State   string           `mapstructure:"state"`
 	UUID    string           `mapstructure:"uuid"`
+	Source  EndPoint         `mapstructure:"source"`
+	Destination EndPoint     `mapstructure:"destination"`
 	Policy  PolicySnapmirror `mapstructure:"policy"`
 }
 
@@ -28,14 +30,15 @@ type SnapmirrorResourceBodyDataModelONTAP struct {
 	DestinationEndPoint EndPoint          `mapstructure:"destination"`
 	CreateDestination   CreateDestination `mapstructure:"create_destination,omitempty"`
 	Policy              PolicySnapmirror  `mapstructure:"policy,omitempty"`
+	State               string            `mapstructure:"state,omitempty"`
 }
 
 // UpdateSnapmirrorResourceBodyDataModelONTAP defines the resource data model
 type UpdateSnapmirrorResourceBodyDataModelONTAP struct {
-	SourceEndPoint      EndPoint         `mapstructure:"source"`
-	DestinationEndPoint EndPoint         `mapstructure:"destination"`
-	Policy              PolicySnapmirror `mapstructure:"policy,omitempty"`
-	State               string           `mapstructure:"state,omitempty"`
+	SourceEndPoint      *EndPoint         `mapstructure:"source,omitempty"`
+	DestinationEndPoint *EndPoint         `mapstructure:"destination,omitempty"`
+	Policy              *PolicySnapmirror `mapstructure:"policy,omitempty"`
+	State               string            `mapstructure:"state,omitempty"`
 }
 
 // PolicySnapmirror describes the resource data model.
@@ -111,7 +114,9 @@ type SnapmirrorPolicy struct {
 // GetSnapmirrorByID ...
 func GetSnapmirrorByID(errorHandler *utils.ErrorHandler, r restclient.RestClient, id string) (*SnapmirrorGetDataModelONTAP, error) {
 	api := "snapmirror/relationships/" + id
-	statusCode, response, err := r.GetNilOrOneRecord(api, nil, nil)
+	query := r.NewQuery()
+	query.Fields([]string{"destination", "healthy", "policy.name", "source", "state", "uuid"})
+	statusCode, response, err := r.GetNilOrOneRecord(api, query, nil)
 	if err == nil && response == nil {
 		err = fmt.Errorf("no response for GET %s", api)
 	}
@@ -241,13 +246,19 @@ func InitializeSnapmirror(errorHandler *utils.ErrorHandler, r restclient.RestCli
 }
 
 // UpdateSnapmirror updates Snapmirror
-func UpdateSnapmirror(errorHandler *utils.ErrorHandler, r restclient.RestClient, data any, uuid string) error {
+func UpdateSnapmirror(errorHandler *utils.ErrorHandler, r restclient.RestClient, data any, uuid string, force bool, quickResync bool) error {
 	var body map[string]interface{}
 	if err := mapstructure.Decode(data, &body); err != nil {
 		return errorHandler.MakeAndReportError("error encoding snapmirror body", fmt.Sprintf("error on encoding snapmirror/relationships body: %s, body: %#v", err, data))
 	}
+	if quickResync {
+		body["quick_resync"] = true
+	}
 	query := r.NewQuery()
 	query.Add("return_records", "true")
+	if force {
+		query.Add("force", "true")
+	}
 	// API has no option to return records
 	statusCode, _, err := r.CallUpdateMethod(fmt.Sprintf("snapmirror/relationships/%s", uuid), query, body)
 	if err != nil {

--- a/internal/provider/snapmirror/snapmirror_resource.go
+++ b/internal/provider/snapmirror/snapmirror_resource.go
@@ -8,7 +8,11 @@ import (
 
 	"github.com/netapp/terraform-provider-netapp-ontap/internal/provider/connection"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -25,6 +29,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces
 var _ resource.Resource = &SnapmirrorResource{}
 var _ resource.ResourceWithImportState = &SnapmirrorResource{}
+var _ resource.ResourceWithModifyPlan = &SnapmirrorResource{}
 
 // NewSnapmirrorResource is a helper function to simplify the provider implementation.
 func NewSnapmirrorResource() resource.Resource {
@@ -57,6 +62,9 @@ type SnapmirrorResourceModel struct {
 	CreateDestination   *CreateDestination `tfsdk:"create_destination"`
 	Policy              *Policy            `tfsdk:"policy"`
 	Initialize          types.Bool         `tfsdk:"initialize"`
+	Force               types.Bool         `tfsdk:"force"`
+	QuickResync         types.Bool         `tfsdk:"quick_resync"`
+	TransferringTimeOut types.Int64        `tfsdk:"transferring_time_out"`
 	Healthy             types.Bool         `tfsdk:"healthy"`
 	State               types.String       `tfsdk:"state"`
 	ID                  types.String       `tfsdk:"id"`
@@ -88,6 +96,11 @@ type Policy struct {
 type TransferSchedule struct {
 	Name types.String `tfsdk:"name"`
 }
+
+const (
+	snapmirrorTransitionTimeout = 2 * time.Minute
+	snapmirrorTransitionPoll    = 5 * time.Second
+)
 
 // Metadata returns the resource type name
 func (r *SnapmirrorResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -161,13 +174,37 @@ func (r *SnapmirrorResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Default:             booldefault.StaticBool(true),
 				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 			},
+			"force": schema.BoolAttribute{
+				MarkdownDescription: "If set to true while specifying state as broken_off, performs a forced failover overriding validation errors.",
+				Optional: true,
+			},
+			"quick_resync": schema.BoolAttribute{
+				MarkdownDescription: "Optional modify-only flag. Set true to speed resync by not preserving storage efficiency; applicable for FlexVol and SVMDR when PATCH state changes to snapmirrored.",
+				Optional:            true,
+			},
+			"transferring_time_out": schema.Int64Attribute{
+				MarkdownDescription: "Maximum time in seconds to wait for SnapMirror state transitions before failing the operation.",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(300),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
 			"healthy": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"state": schema.StringAttribute{
+				MarkdownDescription: "Set state to snapmirrored for async policies or in_sync for sync policies when initializing or resyncing a SnapMirror relationship.",
 				Optional: true,
 				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("broken_off", "paused", "snapmirrored", "uninitialized", "in_sync", "out_of_sync", "synchronizing", "expanding", "shrinking"),
+				},
 			},
 			"policy": schema.SingleNestedAttribute{
 				MarkdownDescription: "policy details",
@@ -196,6 +233,39 @@ func (r *SnapmirrorResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 			},
 		},
+	}
+}
+
+// ModifyPlan suppresses one-shot flag diffs unless they are relevant for the current state transition.
+func (r *SnapmirrorResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan, state *SnapmirrorResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	changed := false
+	stateChanging := !plan.State.Equal(state.State)
+
+	forceRelevant := stateChanging && plan.State.ValueString() == "broken_off"
+	if !forceRelevant && !plan.Force.Equal(state.Force) {
+		plan.Force = state.Force
+		changed = true
+	}
+
+	quickResyncRelevant := stateChanging && state.State.ValueString() == "broken_off"
+	if !quickResyncRelevant && !plan.QuickResync.Equal(state.QuickResync) {
+		plan.QuickResync = state.QuickResync
+		changed = true
+	}
+
+	if changed {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 	}
 }
 
@@ -243,6 +313,15 @@ func (r *SnapmirrorResource) Read(ctx context.Context, req resource.ReadRequest,
 		data.ID = types.StringValue(restInfo.UUID)
 		data.Healthy = types.BoolValue(restInfo.Healthy)
 		data.State = types.StringValue(restInfo.State)
+		if data.SourceEndPoint != nil && restInfo.Source.Path != "" {
+			data.SourceEndPoint.Path = types.StringValue(restInfo.Source.Path)
+		}
+		if data.DestinationEndPoint != nil && restInfo.Destination.Path != "" {
+			data.DestinationEndPoint.Path = types.StringValue(restInfo.Destination.Path)
+		}
+		if data.TransferringTimeOut.IsNull() || data.TransferringTimeOut.IsUnknown() {
+			data.TransferringTimeOut = types.Int64Value(300)
+		}
 		// only refresh policy fields if policy and policy.transfer_schedule were configured
 		// and already exist in prior state
 		if data.Policy != nil {
@@ -267,6 +346,9 @@ func (r *SnapmirrorResource) Read(ctx context.Context, req resource.ReadRequest,
 		data.Healthy = types.BoolValue(restInfoImport.Healthy)
 		data.State = types.StringValue(restInfoImport.State)
 		data.DestinationEndPoint.Path = types.StringValue(restInfoImport.Destination.Path)
+		if data.TransferringTimeOut.IsNull() || data.TransferringTimeOut.IsUnknown() {
+			data.TransferringTimeOut = types.Int64Value(300)
+		}
 		// source_endpoint is a required attribute and is not part of the import ID,
 		// so it has to be filled from the REST response for the imported state to be
 		// usable. The source cluster is left unset on purpose: it is optional in the
@@ -320,6 +402,9 @@ func (r *SnapmirrorResource) Create(ctx context.Context, req resource.CreateRequ
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	if data.TransferringTimeOut.IsNull() || data.TransferringTimeOut.IsUnknown() {
+		data.TransferringTimeOut = types.Int64Value(300)
 	}
 
 	body.SourceEndPoint.Path = data.SourceEndPoint.Path.ValueString()
@@ -380,19 +465,38 @@ func (r *SnapmirrorResource) Create(ctx context.Context, req resource.CreateRequ
 			// error reporting done inside InitializeSnapmirror
 			return
 		}
-		tflog.Debug(errorHandler.Ctx, fmt.Sprintf("Read snapmirror info: %#v", restInfo))
+		// Poll until ONTAP reaches snapmirrored or the transferring_time_out elapses.
+		transitionTimeout := snapmirrorTransitionTimeout
+		if !data.TransferringTimeOut.IsNull() && !data.TransferringTimeOut.IsUnknown() {
+			transitionTimeout = time.Duration(data.TransferringTimeOut.ValueInt64()) * time.Second
+		}
+		deadline := time.Now().Add(transitionTimeout)
+		for {
+			restInfo, err = interfaces.GetSnapmirrorByID(errorHandler, *client, data.ID.ValueString())
+			if err != nil {
+				return
+			}
+			tflog.Debug(errorHandler.Ctx, fmt.Sprintf("waiting for snapmirror snapmirrored state, current: %s", restInfo.State))
+			if restInfo.State == "snapmirrored" {
+				break
+			}
+			if time.Now().After(deadline) {
+				errorHandler.MakeAndReportError("timeout waiting for snapmirror initialization",
+					fmt.Sprintf("expected state snapmirrored, got %s after %s", restInfo.State, transitionTimeout))
+				return
+			}
+			time.Sleep(snapmirrorTransitionPoll)
+		}
+		data.Healthy = types.BoolValue(restInfo.Healthy)
+		data.State = types.StringValue(restInfo.State)
+	} else {
+		restInfo, err = interfaces.GetSnapmirrorByID(errorHandler, *client, data.ID.ValueString())
+		if err != nil {
+			return
+		}
 		data.Healthy = types.BoolValue(restInfo.Healthy)
 		data.State = types.StringValue(restInfo.State)
 	}
-	restInfo, err = interfaces.GetSnapmirrorByID(errorHandler, *client, data.ID.ValueString())
-	if err != nil {
-		// error reporting done inside GetSnapmirror
-		return
-	}
-	tflog.Debug(errorHandler.Ctx, fmt.Sprintf("Read snapmirror info: %#v", restInfo))
-	// Update the computed parameters
-	data.Healthy = types.BoolValue(restInfo.Healthy)
-	data.State = types.StringValue(restInfo.State)
 	data.ID = types.StringValue(resource.UUID)
 
 	tflog.Trace(ctx, fmt.Sprintf("created a snapmirror resource, UUID=%s", data.ID))
@@ -403,12 +507,14 @@ func (r *SnapmirrorResource) Create(ctx context.Context, req resource.CreateRequ
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *SnapmirrorResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state *SnapmirrorResourceModel
+	var plan, state, config *SnapmirrorResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	// Read Terraform state data in to the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	// Read Terraform configuration (used for write-only inputs like quick_resync)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	errorHandler := utils.NewErrorHandler(ctx, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
@@ -424,20 +530,20 @@ func (r *SnapmirrorResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Update the resource
 	var body interfaces.UpdateSnapmirrorResourceBodyDataModelONTAP
 
-	body.SourceEndPoint.Path = plan.SourceEndPoint.Path.ValueString()
-	body.DestinationEndPoint.Path = plan.DestinationEndPoint.Path.ValueString()
-	body.State = plan.State.ValueString()
-	if plan.SourceEndPoint.Cluster != nil {
-		if !plan.SourceEndPoint.Cluster.Name.IsNull() {
+	if !plan.SourceEndPoint.Path.Equal(state.SourceEndPoint.Path) {
+		body.SourceEndPoint = &interfaces.EndPoint{Path: plan.SourceEndPoint.Path.ValueString()}
+		if plan.SourceEndPoint.Cluster != nil && !plan.SourceEndPoint.Cluster.Name.IsNull() {
 			body.SourceEndPoint.Cluster.Name = plan.SourceEndPoint.Cluster.Name.ValueString()
 		}
 	}
-	if plan.DestinationEndPoint.Cluster != nil {
-		if !plan.DestinationEndPoint.Cluster.Name.IsNull() {
+	if !plan.DestinationEndPoint.Path.Equal(state.DestinationEndPoint.Path) {
+		body.DestinationEndPoint = &interfaces.EndPoint{Path: plan.DestinationEndPoint.Path.ValueString()}
+		if plan.DestinationEndPoint.Cluster != nil && !plan.DestinationEndPoint.Cluster.Name.IsNull() {
 			body.DestinationEndPoint.Cluster.Name = plan.DestinationEndPoint.Cluster.Name.ValueString()
 		}
 	}
 	if plan.Policy != nil {
+		body.Policy = &interfaces.PolicySnapmirror{}
 		if !plan.Policy.Name.IsNull() {
 			body.Policy.Name = plan.Policy.Name.ValueString()
 		}
@@ -448,9 +554,45 @@ func (r *SnapmirrorResource) Update(ctx context.Context, req resource.UpdateRequ
 		}
 	}
 
-	err = interfaces.UpdateSnapmirror(errorHandler, *client, body, plan.ID.ValueString())
+	stateChanging := !plan.State.Equal(state.State)
+	if stateChanging {
+		body.State = plan.State.ValueString()
+	}
+
+	// force is passed as a query param only when breaking the relationship and user explicitly set force=true.
+	useForce := stateChanging && plan.State.ValueString() == "broken_off" && plan.Force.ValueBool()
+	// quick_resync is only relevant when moving a relationship from broken_off back to snapmirrored.
+	quickResync := stateChanging &&
+		state.State.ValueString() == "broken_off" &&
+		!config.QuickResync.IsNull() &&
+		!config.QuickResync.IsUnknown() &&
+		config.QuickResync.ValueBool()
+	err = interfaces.UpdateSnapmirror(errorHandler, *client, body, plan.ID.ValueString(), useForce, quickResync)
 	if err != nil {
 		return
+	}
+
+	if stateChanging {
+		desiredState := plan.State.ValueString()
+		transitionTimeout := snapmirrorTransitionTimeout
+		if !plan.TransferringTimeOut.IsNull() && !plan.TransferringTimeOut.IsUnknown() {
+			transitionTimeout = time.Duration(plan.TransferringTimeOut.ValueInt64()) * time.Second
+		}
+		deadline := time.Now().Add(transitionTimeout)
+		for {
+			restInfo, err := interfaces.GetSnapmirrorByID(errorHandler, *client, plan.ID.ValueString())
+			if err != nil {
+				return
+			}
+			if restInfo.State == desiredState {
+				break
+			}
+			if time.Now().After(deadline) {
+				errorHandler.MakeAndReportError("timeout waiting for snapmirror state transition", fmt.Sprintf("expected state %s, got %s", desiredState, restInfo.State))
+				return
+			}
+			time.Sleep(snapmirrorTransitionPoll)
+		}
 	}
 
 	restInfo, err := interfaces.GetSnapmirrorByID(errorHandler, *client, plan.ID.ValueString())
@@ -461,6 +603,12 @@ func (r *SnapmirrorResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Update the computed parameters
 	plan.Healthy = types.BoolValue(restInfo.Healthy)
 	plan.State = types.StringValue(restInfo.State)
+	if plan.SourceEndPoint != nil && restInfo.Source.Path != "" {
+		plan.SourceEndPoint.Path = types.StringValue(restInfo.Source.Path)
+	}
+	if plan.DestinationEndPoint != nil && restInfo.Destination.Path != "" {
+		plan.DestinationEndPoint.Path = types.StringValue(restInfo.Destination.Path)
+	}
 
 	tflog.Debug(ctx, fmt.Sprintf("updated a snapmirror resource: UUID=%s", plan.ID))
 

--- a/internal/provider/snapmirror/snapmirror_resource.go
+++ b/internal/provider/snapmirror/snapmirror_resource.go
@@ -176,11 +176,17 @@ func (r *SnapmirrorResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"force": schema.BoolAttribute{
 				MarkdownDescription: "If set to true while specifying state as broken_off, performs a forced failover overriding validation errors.",
-				Optional: true,
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"quick_resync": schema.BoolAttribute{
 				MarkdownDescription: "Optional modify-only flag. Set true to speed resync by not preserving storage efficiency; applicable for FlexVol and SVMDR when PATCH state changes to snapmirrored.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"transferring_time_out": schema.Int64Attribute{
 				MarkdownDescription: "Maximum time in seconds to wait for SnapMirror state transitions before failing the operation.",
@@ -322,6 +328,12 @@ func (r *SnapmirrorResource) Read(ctx context.Context, req resource.ReadRequest,
 		if data.TransferringTimeOut.IsNull() || data.TransferringTimeOut.IsUnknown() {
 			data.TransferringTimeOut = types.Int64Value(300)
 		}
+		if data.Force.IsNull() || data.Force.IsUnknown() {
+			data.Force = types.BoolValue(false)
+		}
+		if data.QuickResync.IsNull() || data.QuickResync.IsUnknown() {
+			data.QuickResync = types.BoolValue(false)
+		}
 		// only refresh policy fields if policy and policy.transfer_schedule were configured
 		// and already exist in prior state
 		if data.Policy != nil {
@@ -348,6 +360,12 @@ func (r *SnapmirrorResource) Read(ctx context.Context, req resource.ReadRequest,
 		data.DestinationEndPoint.Path = types.StringValue(restInfoImport.Destination.Path)
 		if data.TransferringTimeOut.IsNull() || data.TransferringTimeOut.IsUnknown() {
 			data.TransferringTimeOut = types.Int64Value(300)
+		}
+		if data.Force.IsNull() || data.Force.IsUnknown() {
+			data.Force = types.BoolValue(false)
+		}
+		if data.QuickResync.IsNull() || data.QuickResync.IsUnknown() {
+			data.QuickResync = types.BoolValue(false)
 		}
 		// source_endpoint is a required attribute and is not part of the import ID,
 		// so it has to be filled from the REST response for the imported state to be

--- a/internal/provider/snapmirror/snapmirror_resource_test.go
+++ b/internal/provider/snapmirror/snapmirror_resource_test.go
@@ -21,31 +21,51 @@ func TestAccSnapmirrorResource(t *testing.T) {
 				Config:      testAccSnapmirrorResourceBasicConfig("tf_peer:tf_acc_svm", "terraform:tf_acc_svm"),
 				ExpectError: regexp.MustCompile("13304105"),
 			},
-			// // Create snapmirror and read
-			// {
-			// 	Config: testAccSnapmirrorResourceBasicConfig("tf_peer:snap_source2", "terraform:snap_dest2"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_snapmirror.example", "destination_endpoint.path", "terraform:snap_dest2"),
-			// 	),
-			// },
-			// // Update a policy
-			// {
-			// 	Config: testAccSnapmirrorResourceUpdateConfig("tf_peer:snap_source", "terraform:snap_dest", "MirrorAndVault"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_snapmirror.example", "policy.name", "MirrorAndVault"),
-			// 		resource.TestCheckResourceAttr("netapp-ontap_snapmirror.example", "destination_endpoint.path", "terraform:snap_dest"),
-			// 	),
-			// },
-			// // Import and read
-			// {
-			// 	ResourceName:  "netapp-ontap_snapmirror.example",
-			// 	ImportState:   true,
-			// 	ImportStateId: fmt.Sprintf("%s,%s", "terraform:snap_dest", "cluster4"),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr("netapp-ontap_snapmirror.example", "destination_endpoint.path", "terraform:snap_dest"),
-			// 	),
-			// },
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccSnapmirrorResourceBreakResyncOptions(t *testing.T) {
+	sourcePath := os.Getenv("TF_ACC_SNAPMIRROR_SOURCE_PATH")
+	destinationPath := os.Getenv("TF_ACC_SNAPMIRROR_DESTINATION_PATH")
+	if sourcePath == "" || destinationPath == "" {
+		t.Skip("set TF_ACC_SNAPMIRROR_SOURCE_PATH and TF_ACC_SNAPMIRROR_DESTINATION_PATH to run break/resync acceptance test")
+	}
+
+	resourceName := "netapp-ontap_snapmirror.example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { ntest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ntest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create relationship with initialize and custom timeout.
+			{
+				Config: testAccSnapmirrorResourceBreakResyncConfig(sourcePath, destinationPath, "snapmirrored", false, false, true, 600),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "source_endpoint.path", sourcePath),
+					resource.TestCheckResourceAttr(resourceName, "destination_endpoint.path", destinationPath),
+					resource.TestCheckResourceAttr(resourceName, "initialize", "true"),
+					resource.TestCheckResourceAttr(resourceName, "transferring_time_out", "600"),
+				),
+			},
+			// Break relationship with force=true.
+			{
+				Config: testAccSnapmirrorResourceBreakResyncConfig(sourcePath, destinationPath, "broken_off", true, false, true, 600),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "broken_off"),
+					resource.TestCheckResourceAttr(resourceName, "force", "true"),
+					resource.TestCheckResourceAttr(resourceName, "quick_resync", "false"),
+				),
+			},
+			// Resync relationship with quick_resync=true.
+			{
+				Config: testAccSnapmirrorResourceBreakResyncConfig(sourcePath, destinationPath, "snapmirrored", false, true, true, 600),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "snapmirrored"),
+					resource.TestCheckResourceAttr(resourceName, "quick_resync", "true"),
+				),
+			},
 		},
 	})
 }
@@ -79,40 +99,45 @@ resource "netapp-ontap_snapmirror" "example" {
   destination_endpoint = {
     path = "%s"
   }
-}`, host, admin, password, sourceEndpoint, destinationEndpoint)
+}
+`, host, admin, password, sourceEndpoint, destinationEndpoint)
 }
 
-// func testAccSnapmirrorResourceUpdateConfig(sourceEndpoint string, destinationEndpoint string, policy string) string {
-// 	host := os.Getenv("TF_ACC_NETAPP_HOST")
-// 	admin := os.Getenv("TF_ACC_NETAPP_USER")
-// 	password := os.Getenv("TF_ACC_NETAPP_PASS")
-// 	if host == "" || admin == "" || password == "" {
-// 		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
-// 		os.Exit(1)
-// 	}
-// 	return fmt.Sprintf(`
-// provider "netapp-ontap" {
-//  connection_profiles = [
-//     {
-//       name = "cluster4"
-//       hostname = "%s"
-//       username = "%s"
-//       password = "%s"
-//       validate_certs = false
-//     },
-//   ]
-// }
+func testAccSnapmirrorResourceBreakResyncConfig(sourceEndpoint string, destinationEndpoint string, state string, force bool, quickResync bool, initialize bool, transferringTimeOut int) string {
+	host := os.Getenv("TF_ACC_NETAPP_HOST")
+	admin := os.Getenv("TF_ACC_NETAPP_USER")
+	password := os.Getenv("TF_ACC_NETAPP_PASS")
+	if host == "" || admin == "" || password == "" {
+		fmt.Println("TF_ACC_NETAPP_HOST, TF_ACC_NETAPP_USER, and TF_ACC_NETAPP_PASS must be set for acceptance tests")
+		os.Exit(1)
+	}
 
-// resource "netapp-ontap_snapmirror" "example" {
-//   cx_profile_name = "cluster4"
-//   source_endpoint = {
-//     path = "%s"
-//   }
-//   destination_endpoint = {
-//     path = "%s"
-//   }
-//   policy = {
-// 	name = "%s"
-//   }
-// }`, host, admin, password, sourceEndpoint, destinationEndpoint, policy)
-// }
+	return fmt.Sprintf(`
+provider "netapp-ontap" {
+ connection_profiles = [
+    {
+      name = "cluster4"
+      hostname = "%s"
+      username = "%s"
+      password = "%s"
+      validate_certs = false
+    },
+  ]
+}
+
+resource "netapp-ontap_snapmirror" "example" {
+  cx_profile_name = "cluster4"
+  source_endpoint = {
+    path = "%s"
+  }
+  destination_endpoint = {
+    path = "%s"
+  }
+  initialize            = %t
+  state                 = "%s"
+  force                 = %t
+  quick_resync          = %t
+  transferring_time_out = %d
+}
+`, host, admin, password, sourceEndpoint, destinationEndpoint, initialize, state, force, quickResync, transferringTimeOut)
+}

--- a/scripts/bd_scan.bash
+++ b/scripts/bd_scan.bash
@@ -7,7 +7,7 @@ help_and_exit () {
 
 # change these 2 values to reflect your project name and version:
 export DETECT_PROJECT_NAME="Terraform NetApp ONTAP Provider"
-export DETECT_PROJECT_VERSION_NAME=2.7.1
+export DETECT_PROJECT_VERSION_NAME=2.8.0
 export DETECT_CODE_LOCATION_NAME="${DETECT_PROJECT_NAME}_${DETECT_PROJECT_VERSION_NAME}_code"
 export DETECT_BOM_AGGREGATE_NAME="${DETECT_PROJECT_NAME}_${DETECT_PROJECT_VERSION_NAME}_bom"
 


### PR DESCRIPTION
1. Added snapmirror state in update to change the state of snapmirror relationship from snapmirrored to broken_off and then resync
2. Added quick_resync for resync function.
3. Added force break to break the relationship by skipping the validation errors.
4. Updated Acc tests
5. Added entries in changelog.